### PR TITLE
Fix host app memory growth during Steam Controller input

### DIFF
--- a/crates/crosspuck-app/Cargo.toml
+++ b/crates/crosspuck-app/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 license.workspace = true
 description = "macOS menu bar shell for the CrossPuck host service"
 
+[features]
+default = []
+profiling = ["dep:pprof"]
+
 [[bin]]
 name = "CrossPuck"
 path = "src/main.rs"
@@ -43,3 +47,4 @@ objc2-foundation = { workspace = true, features = [
     "NSTimer",
 ] }
 oslog.workspace = true
+pprof = { version = "0.15.0", optional = true, features = ["flamegraph"] }

--- a/crates/crosspuck-app/src/hid_backend.rs
+++ b/crates/crosspuck-app/src/hid_backend.rs
@@ -6,6 +6,7 @@ use crosspuck_core::protocol::{
     session_trace_label, CollectionRole, FeatureResult, GetFeature, IdentityPayload, SetFeature,
     SetFeatureResult, SetOutput, SetOutputResult, StatusCode, WriteReport, WriteResult,
 };
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -18,7 +19,6 @@ const FEATURE_REPORT_RETRY_DELAY: Duration = Duration::from_millis(2);
 const INPUT_REOPEN_BACKOFF: Duration = Duration::from_millis(25);
 const INPUT_ERROR_GRACE: Duration = Duration::from_secs(30);
 const INPUT_DISCONNECT_GRACE: Duration = Duration::from_secs(120);
-const INPUT_IDLE_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 static HOST_LOG_SESSION_TRACE_ID: Mutex<Option<u32>> = Mutex::new(None);
 
@@ -81,6 +81,7 @@ pub(crate) struct RealHostBackend {
     snapshot: Arc<Mutex<PuckSnapshot>>,
     identity: IdentityPayload,
     main: SharedMainDevice,
+    interface_devices: Arc<Mutex<BTreeMap<u8, CachedInterfaceDevice>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -90,6 +91,12 @@ struct SharedMainDevice {
     command_device: Arc<Mutex<HidDevice>>,
 }
 
+#[derive(Debug)]
+struct CachedInterfaceDevice {
+    path: String,
+    device: HidDevice,
+}
+
 impl RealHostBackend {
     pub fn new(snapshot: PuckSnapshot, identity: IdentityPayload) -> Result<Self, HostHidError> {
         let main = Self::open_main_device(&snapshot)?;
@@ -97,6 +104,7 @@ impl RealHostBackend {
             snapshot: Arc::new(Mutex::new(snapshot)),
             identity,
             main,
+            interface_devices: Arc::new(Mutex::new(BTreeMap::new())),
         })
     }
 
@@ -122,12 +130,12 @@ impl RealHostBackend {
         Some(path)
     }
 
-    fn paths_for_interface(&self, interface_number: u8) -> Vec<String> {
+    fn candidate_paths_for_interface(&self, interface_number: u8) -> Vec<String> {
         let mut paths = Vec::new();
-        if let Some(path) = self.refresh_path_for_interface(interface_number) {
+        if let Some(path) = self.cached_path_for_interface(interface_number) {
             paths.push(path);
         }
-        if let Some(path) = self.cached_path_for_interface(interface_number) {
+        if let Some(path) = self.refresh_path_for_interface(interface_number) {
             push_unique_path(&mut paths, path);
         }
         paths
@@ -142,9 +150,11 @@ impl RealHostBackend {
     }
 
     fn refresh_main_device(&self) -> Result<(), HostHidError> {
+        crate::probe::note_hid_main_refresh_attempt();
         let snapshot = snapshot_for_filter(&HidFilter::steam_puck())?;
         let path = Self::path_in_snapshot(&snapshot, self.main.interface_number)
             .ok_or(HostHidError::MissingCollection(HidCollectionRole::PuckMain))?;
+        crate::probe::note_hid_open_path_attempt();
         let device = open_path_with_new_api(&path)?;
 
         *self
@@ -160,6 +170,7 @@ impl RealHostBackend {
         if let Ok(mut current) = self.snapshot.lock() {
             *current = snapshot;
         }
+        crate::probe::note_hid_main_refresh_ok();
         Ok(())
     }
 
@@ -171,6 +182,7 @@ impl RealHostBackend {
             .ok_or(HostHidError::MissingCollection(HidCollectionRole::PuckMain))?;
         let interface_number = u8::try_from(collection.interface_number)
             .map_err(|_| HostHidError::InvalidInterfaceNumber(collection.interface_number))?;
+        crate::probe::note_hid_open_path_attempt();
         let device = open_path_with_new_api(&collection.path)?;
         Ok(SharedMainDevice {
             interface_number,
@@ -217,6 +229,7 @@ impl RealHostBackend {
             role: CollectionRole::from(collection.role),
         };
         if self.is_main_interface(interface_number) {
+            crate::probe::note_hid_open_path_attempt();
             let device = open_path_with_new_api(&collection.path)?;
             return Ok(CollectionInputReader::new(
                 self.clone(),
@@ -227,6 +240,7 @@ impl RealHostBackend {
             ));
         }
 
+        crate::probe::note_hid_open_path_attempt();
         let device = open_path_with_new_api(&collection.path)?;
         Ok(CollectionInputReader::new(
             self.clone(),
@@ -242,6 +256,7 @@ impl RealHostBackend {
         interface_number: u8,
         role: CollectionRole,
     ) -> Result<(String, u16, HidDevice), HostHidError> {
+        crate::probe::note_hid_interface_reopen_attempt();
         let snapshot = snapshot_for_filter(&HidFilter::steam_puck())?;
         let collection = snapshot
             .collections
@@ -253,10 +268,12 @@ impl RealHostBackend {
             .ok_or_else(|| HostHidError::MissingCollection(hid_role_for_protocol_role(role)))?;
         let path = collection.path.clone();
         let input_report_len = collection.input_report_len;
+        crate::probe::note_hid_open_path_attempt();
         let device = open_path_with_new_api(&path)?;
         if let Ok(mut current) = self.snapshot.lock() {
             *current = snapshot;
         }
+        crate::probe::note_hid_interface_reopen_ok();
         Ok((path, input_report_len, device))
     }
 
@@ -299,40 +316,113 @@ impl RealHostBackend {
             };
         }
 
-        let paths = self.paths_for_interface(interface_number);
-        if paths.is_empty() {
-            return WriteResult {
+        match self.write_interface_with_retry(interface_number, data) {
+            Ok(written) => WriteResult {
+                status: StatusCode::Ok,
+                bytes_written: saturating_u16(written),
+                os_error: 0,
+            },
+            Err(error) if error.paths.is_empty() => WriteResult {
                 status: StatusCode::UnsupportedInterface,
                 bytes_written: 0,
                 os_error: 0,
-            };
+            },
+            Err(error) => {
+                warn_host_guest_event!(
+                    "HID write failed: interface={} paths={} len={} error={}",
+                    interface_number,
+                    describe_paths(&error.paths),
+                    data.len(),
+                    error.message
+                );
+                WriteResult {
+                    status: StatusCode::HidIoError,
+                    bytes_written: 0,
+                    os_error: 0,
+                }
+            }
+        }
+    }
+
+    fn open_cached_interface_device(
+        &self,
+        interface_number: u8,
+    ) -> Result<CachedInterfaceDevice, FeatureReportError> {
+        let paths = self.candidate_paths_for_interface(interface_number);
+        if paths.is_empty() {
+            return Err(FeatureReportError {
+                paths,
+                message: "no matching HID path".to_string(),
+            });
         }
 
         let mut last_error = None;
         for path in &paths {
-            match open_path_with_new_api(path)
-                .and_then(|device| device.write(data).map_err(Into::into))
-            {
-                Ok(written) => {
-                    return WriteResult {
-                        status: StatusCode::Ok,
-                        bytes_written: saturating_u16(written),
-                        os_error: 0,
-                    };
+            crate::probe::note_hid_open_path_attempt();
+            match open_path_with_new_api(path) {
+                Ok(device) => {
+                    return Ok(CachedInterfaceDevice {
+                        path: path.clone(),
+                        device,
+                    });
                 }
-                Err(error) => last_error = Some(error),
+                Err(error) => last_error = Some(error.to_string()),
             }
         }
 
-        let error = last_error.expect("paths must not be empty");
-        warn_host_guest_event!(
-            "HID write failed: interface={} paths={} len={} error={}",
-            interface_number,
-            describe_paths(&paths),
-            data.len(),
-            error
-        );
-        hid_write_error(error)
+        Err(FeatureReportError {
+            paths,
+            message: last_error.unwrap_or_else(|| "no matching HID path".to_string()),
+        })
+    }
+
+    fn cached_interface_device<'a>(
+        &'a self,
+        devices: &'a mut BTreeMap<u8, CachedInterfaceDevice>,
+        interface_number: u8,
+    ) -> Result<&'a mut CachedInterfaceDevice, FeatureReportError> {
+        if !devices.contains_key(&interface_number) {
+            let device = self.open_cached_interface_device(interface_number)?;
+            devices.insert(interface_number, device);
+        }
+        Ok(devices
+            .get_mut(&interface_number)
+            .expect("cached interface device must exist after insertion"))
+    }
+
+    fn write_interface_with_retry(
+        &self,
+        interface_number: u8,
+        data: &[u8],
+    ) -> Result<usize, FeatureReportError> {
+        let mut last_error = None;
+        let mut last_paths = Vec::new();
+        for attempt in 0..FEATURE_REPORT_ATTEMPTS {
+            if attempt > 0 {
+                thread::sleep(FEATURE_REPORT_RETRY_DELAY);
+            }
+            let mut devices = self
+                .interface_devices
+                .lock()
+                .map_err(|_| FeatureReportError {
+                    paths: last_paths.clone(),
+                    message: "HID interface device cache lock poisoned".to_string(),
+                })?;
+            let device = self.cached_interface_device(&mut devices, interface_number)?;
+            last_paths = vec![device.path.clone()];
+            match device.device.write(data) {
+                Ok(written) => return Ok(written),
+                Err(error) => {
+                    last_error = Some(error.to_string());
+                    devices.remove(&interface_number);
+                }
+            }
+        }
+
+        Err(FeatureReportError {
+            paths: last_paths,
+            message: last_error.unwrap_or_else(|| "unknown HID write error".to_string()),
+        })
     }
 }
 
@@ -364,8 +454,8 @@ impl HostBackend for RealHostBackend {
         let result = if self.is_main_interface(request.interface_number) {
             self.get_main_feature_report_with_retry(request.report_id, &mut buffer)
         } else {
-            get_feature_report_with_retry(
-                || self.paths_for_interface(request.interface_number),
+            self.get_interface_feature_report_with_retry(
+                request.interface_number,
                 request.report_id,
                 &mut buffer,
             )
@@ -398,11 +488,7 @@ impl HostBackend for RealHostBackend {
         let result = if self.is_main_interface(request.interface_number) {
             self.send_main_feature_report_with_retry(request.interface_number, &request.data)
         } else {
-            send_feature_report_with_retry(
-                || self.paths_for_interface(request.interface_number),
-                request.interface_number,
-                &request.data,
-            )
+            self.send_interface_feature_report_with_retry(request.interface_number, &request.data)
         };
         match result {
             Ok(accepted) => SetFeatureResult {
@@ -527,81 +613,85 @@ impl RealHostBackend {
             message: last_error.unwrap_or_else(|| "unknown HID set_feature error".to_string()),
         })
     }
-}
 
-fn get_feature_report_with_retry(
-    mut paths_for_attempt: impl FnMut() -> Vec<String>,
-    report_id: u8,
-    buffer: &mut [u8],
-) -> Result<usize, FeatureReportError> {
-    let mut last_error = None;
-    let mut last_paths = Vec::new();
-    for attempt in 0..FEATURE_REPORT_ATTEMPTS {
-        if attempt > 0 {
-            thread::sleep(FEATURE_REPORT_RETRY_DELAY);
-        }
-        let paths = paths_for_attempt();
-        if paths.is_empty() {
-            continue;
-        }
-        last_paths = paths.clone();
-        for path in &paths {
+    fn get_interface_feature_report_with_retry(
+        &self,
+        interface_number: u8,
+        report_id: u8,
+        buffer: &mut [u8],
+    ) -> Result<usize, FeatureReportError> {
+        let mut last_error = None;
+        let mut last_paths = Vec::new();
+        for attempt in 0..FEATURE_REPORT_ATTEMPTS {
+            if attempt > 0 {
+                thread::sleep(FEATURE_REPORT_RETRY_DELAY);
+            }
+            let mut devices = self
+                .interface_devices
+                .lock()
+                .map_err(|_| FeatureReportError {
+                    paths: last_paths.clone(),
+                    message: "HID interface device cache lock poisoned".to_string(),
+                })?;
+            let device = self.cached_interface_device(&mut devices, interface_number)?;
+            last_paths = vec![device.path.clone()];
             buffer.fill(0);
             if let Some(first) = buffer.first_mut() {
                 *first = report_id;
             }
-            match open_path_with_new_api(path)
-                .and_then(|device| device.get_feature_report(buffer).map_err(Into::into))
-            {
+            match device.device.get_feature_report(buffer) {
                 Ok(read) => return Ok(read),
-                Err(error) => last_error = Some(error.to_string()),
+                Err(error) => {
+                    last_error = Some(error.to_string());
+                    devices.remove(&interface_number);
+                }
             }
         }
-    }
-    Err(FeatureReportError {
-        paths: last_paths,
-        message: last_error.unwrap_or_else(|| "no matching HID path".to_string()),
-    })
-}
 
-fn send_feature_report_with_retry(
-    mut paths_for_attempt: impl FnMut() -> Vec<String>,
-    interface_number: u8,
-    data: &[u8],
-) -> Result<usize, FeatureReportError> {
-    let mut last_error = None;
-    let mut last_paths = Vec::new();
-    for attempt in 0..FEATURE_REPORT_ATTEMPTS {
-        if attempt > 0 {
-            thread::sleep(FEATURE_REPORT_RETRY_DELAY);
-        }
-        let paths = paths_for_attempt();
-        if paths.is_empty() {
-            continue;
-        }
-        last_paths = paths.clone();
-        for path in &paths {
-            match open_path_with_new_api(path).and_then(|device| {
-                device
-                    .send_feature_report(data)
-                    .map(|()| data.len())
-                    .map_err(Into::into)
-            }) {
-                Ok(accepted) => return Ok(accepted),
+        Err(FeatureReportError {
+            paths: last_paths,
+            message: last_error.unwrap_or_else(|| "no matching HID path".to_string()),
+        })
+    }
+
+    fn send_interface_feature_report_with_retry(
+        &self,
+        interface_number: u8,
+        data: &[u8],
+    ) -> Result<usize, FeatureReportError> {
+        let mut last_error = None;
+        let mut last_paths = Vec::new();
+        for attempt in 0..FEATURE_REPORT_ATTEMPTS {
+            if attempt > 0 {
+                thread::sleep(FEATURE_REPORT_RETRY_DELAY);
+            }
+            let mut devices = self
+                .interface_devices
+                .lock()
+                .map_err(|_| FeatureReportError {
+                    paths: last_paths.clone(),
+                    message: "HID interface device cache lock poisoned".to_string(),
+                })?;
+            let device = self.cached_interface_device(&mut devices, interface_number)?;
+            last_paths = vec![device.path.clone()];
+            match device.device.send_feature_report(data) {
+                Ok(()) => return Ok(data.len()),
                 Err(error) => {
                     let message = error.to_string();
                     if should_accept_transient_set_feature_error(interface_number, data, &message) {
                         return Ok(data.len());
                     }
                     last_error = Some(message);
+                    devices.remove(&interface_number);
                 }
             }
         }
+
+        Err(FeatureReportError {
+            paths: last_paths,
+            message: last_error.unwrap_or_else(|| "no matching HID path".to_string()),
+        })
     }
-    Err(FeatureReportError {
-        paths: last_paths,
-        message: last_error.unwrap_or_else(|| "no matching HID path".to_string()),
-    })
 }
 
 #[derive(Debug)]
@@ -680,9 +770,6 @@ struct CollectionInputReader {
     buffer: Vec<u8>,
     first_error_at: Option<Instant>,
     consecutive_errors: u32,
-    last_activity_at: Instant,
-    last_idle_refresh_at: Instant,
-    idle_timeouts: u32,
 }
 
 impl CollectionInputReader {
@@ -702,9 +789,6 @@ impl CollectionInputReader {
             buffer: vec![0_u8; usize::from(input_report_len).max(64)],
             first_error_at: None,
             consecutive_errors: 0,
-            last_activity_at: Instant::now(),
-            last_idle_refresh_at: Instant::now(),
-            idle_timeouts: 0,
         }
     }
 
@@ -724,14 +808,11 @@ impl CollectionInputReader {
             Ok(0) => {
                 self.first_error_at = None;
                 self.consecutive_errors = 0;
-                self.note_idle_timeout();
                 Ok(None)
             }
             Ok(read) => {
                 self.first_error_at = None;
                 self.consecutive_errors = 0;
-                self.last_activity_at = Instant::now();
-                self.idle_timeouts = 0;
                 Ok(Some(HostInputReport {
                     descriptor: self.descriptor,
                     data: self.buffer[..read].to_vec(),
@@ -742,7 +823,6 @@ impl CollectionInputReader {
                 if is_hid_read_timeout_waiting_for_data(&error_message) {
                     self.first_error_at = None;
                     self.consecutive_errors = 0;
-                    self.note_idle_timeout();
                     return Ok(None);
                 }
                 let grace = if is_hid_read_timeout_device_disconnected(&error_message) {
@@ -767,8 +847,10 @@ impl CollectionInputReader {
                 }
 
                 if self.consecutive_errors == 1 || self.consecutive_errors.is_multiple_of(4) {
+                    crate::probe::note_hid_error_reopen_attempt();
                     match self.refresh_device() {
                         Ok(()) => {
+                            crate::probe::note_hid_error_reopen_ok();
                             self.first_error_at = None;
                             self.consecutive_errors = 0;
                         }
@@ -795,26 +877,6 @@ impl CollectionInputReader {
                 thread::sleep(INPUT_REOPEN_BACKOFF);
                 Ok(None)
             }
-        }
-    }
-
-    fn note_idle_timeout(&mut self) {
-        if self.descriptor.role != CollectionRole::PuckMain {
-            return;
-        }
-
-        self.idle_timeouts = self.idle_timeouts.saturating_add(1);
-
-        let now = Instant::now();
-        if now.duration_since(self.last_activity_at) < INPUT_IDLE_REFRESH_INTERVAL
-            || now.duration_since(self.last_idle_refresh_at) < INPUT_IDLE_REFRESH_INTERVAL
-        {
-            return;
-        }
-
-        self.last_idle_refresh_at = now;
-        if self.refresh_device().is_ok() {
-            self.idle_timeouts = 0;
         }
     }
 
@@ -926,14 +988,6 @@ fn is_hid_read_timeout_device_disconnected(message: &str) -> bool {
 
 fn saturating_u16(value: usize) -> u16 {
     value.min(u16::MAX as usize) as u16
-}
-
-fn hid_write_error(_error: HidSnapshotError) -> WriteResult {
-    WriteResult {
-        status: StatusCode::HidIoError,
-        bytes_written: 0,
-        os_error: 0,
-    }
 }
 
 #[derive(Debug)]

--- a/crates/crosspuck-app/src/main.rs
+++ b/crates/crosspuck-app/src/main.rs
@@ -8,6 +8,29 @@ mod driver_install;
 mod hid_backend;
 #[cfg(target_os = "macos")]
 mod logging;
+#[cfg(all(target_os = "macos", feature = "profiling"))]
+mod probe;
+#[cfg(all(target_os = "macos", not(feature = "profiling")))]
+mod probe {
+    pub(crate) fn start_from_env() {}
+    pub(crate) fn note_ui_timer_tick() {}
+    pub(crate) fn note_menu_will_open() {}
+    pub(crate) fn note_menu_refresh() {}
+    pub(crate) fn note_driver_status_check() {}
+    pub(crate) fn note_control_frame() {}
+    pub(crate) fn note_input_report() {}
+    pub(crate) fn note_hid_open_path_attempt() {}
+    pub(crate) fn note_hid_interface_reopen_attempt() {}
+    pub(crate) fn note_hid_interface_reopen_ok() {}
+    pub(crate) fn note_hid_error_reopen_attempt() {}
+    pub(crate) fn note_hid_error_reopen_ok() {}
+    pub(crate) fn note_hid_main_refresh_attempt() {}
+    pub(crate) fn note_hid_main_refresh_ok() {}
+
+    pub(crate) fn with_callback_autorelease_pool<T>(body: impl FnOnce() -> T) -> T {
+        body()
+    }
+}
 #[cfg(target_os = "macos")]
 mod runtime;
 
@@ -87,24 +110,32 @@ mod macos {
         unsafe impl NSMenuDelegate for StateMenuDelegate {
             #[unsafe(method(menuWillOpen:))]
             fn menu_will_open(&self, _menu: &NSMenu) {
-                self.ivars().driver_state.refresh_status();
-                refresh_state_items(
-                    &self.ivars().app_state,
-                    &self.ivars().driver_state,
-                    &self.ivars().items,
-                );
+                crate::probe::note_menu_will_open();
+                let refresh = || {
+                    self.ivars().driver_state.refresh_status();
+                    refresh_state_items(
+                        &self.ivars().app_state,
+                        &self.ivars().driver_state,
+                        &self.ivars().items,
+                    );
+                };
+                crate::probe::with_callback_autorelease_pool(refresh);
             }
         }
 
         impl StateMenuDelegate {
             #[unsafe(method(refreshTimer:))]
             fn refresh_timer(&self, _timer: &NSTimer) {
-                self.ivars().driver_state.refresh_status_throttled();
-                refresh_state_items(
-                    &self.ivars().app_state,
-                    &self.ivars().driver_state,
-                    &self.ivars().items,
-                );
+                crate::probe::note_ui_timer_tick();
+                let refresh = || {
+                    self.ivars().driver_state.refresh_status_throttled();
+                    refresh_state_items(
+                        &self.ivars().app_state,
+                        &self.ivars().driver_state,
+                        &self.ivars().items,
+                    );
+                };
+                crate::probe::with_callback_autorelease_pool(refresh);
             }
         }
     );
@@ -211,6 +242,7 @@ mod macos {
         if logging_initialized {
             crate::logging::log_startup(&logging_config);
         }
+        crate::probe::start_from_env();
 
         let mtm = MainThreadMarker::new().expect("crosspuck-app must run on the main thread");
 
@@ -360,6 +392,7 @@ mod macos {
         driver_state: &DriverMenuState,
         items: &StateMenuItems,
     ) {
+        crate::probe::note_menu_refresh();
         let view = app_state.snapshot().menu_view();
         items
             .status
@@ -422,6 +455,7 @@ mod macos {
             if self.is_installing() {
                 return;
             }
+            crate::probe::note_driver_status_check();
 
             let status = check_driver_install_status(&self.context);
             if let Ok(mut snapshot) = self.snapshot.lock() {

--- a/crates/crosspuck-app/src/probe.rs
+++ b/crates/crosspuck-app/src/probe.rs
@@ -1,0 +1,511 @@
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{self, Command};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use objc2_foundation::NSAutoreleasePool;
+
+const PROBE_ENV: &str = "CROSSPUCK_PROBE";
+const PROBE_DIR_ENV: &str = "CROSSPUCK_PROBE_DIR";
+const PROBE_INTERVAL_MS_ENV: &str = "CROSSPUCK_PROBE_INTERVAL_MS";
+const PROBE_VMMAP_INTERVAL_MS_ENV: &str = "CROSSPUCK_PROBE_VMMAP_INTERVAL_MS";
+const PROBE_CPU_SECONDS_ENV: &str = "CROSSPUCK_PROBE_CPU_SECONDS";
+const PROBE_CPU_HZ_ENV: &str = "CROSSPUCK_PROBE_CPU_HZ";
+const PROBE_CALLBACK_POOL_ENV: &str = "CROSSPUCK_PROBE_AUTORELEASE_POOL";
+
+const DEFAULT_PROBE_INTERVAL: Duration = Duration::from_secs(5);
+const DEFAULT_VMMAP_INTERVAL: Duration = Duration::from_secs(30);
+const DEFAULT_CPU_HZ: i32 = 99;
+
+static STARTED: AtomicBool = AtomicBool::new(false);
+static CALLBACK_AUTORELEASE_POOL: AtomicBool = AtomicBool::new(false);
+
+static UI_TIMER_TICKS: AtomicU64 = AtomicU64::new(0);
+static MENU_WILL_OPEN: AtomicU64 = AtomicU64::new(0);
+static MENU_REFRESHES: AtomicU64 = AtomicU64::new(0);
+static DRIVER_STATUS_CHECKS: AtomicU64 = AtomicU64::new(0);
+static CONTROL_FRAMES: AtomicU64 = AtomicU64::new(0);
+static INPUT_REPORTS: AtomicU64 = AtomicU64::new(0);
+static HID_OPEN_PATH_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
+static HID_INTERFACE_REOPENS: AtomicU64 = AtomicU64::new(0);
+static HID_INTERFACE_REOPEN_OK: AtomicU64 = AtomicU64::new(0);
+static HID_IDLE_REOPEN_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
+static HID_IDLE_REOPEN_OK: AtomicU64 = AtomicU64::new(0);
+static HID_ERROR_REOPEN_ATTEMPTS: AtomicU64 = AtomicU64::new(0);
+static HID_ERROR_REOPEN_OK: AtomicU64 = AtomicU64::new(0);
+static HID_MAIN_REFRESHES: AtomicU64 = AtomicU64::new(0);
+static HID_MAIN_REFRESH_OK: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug)]
+struct ProbeConfig {
+    pid: u32,
+    dir: PathBuf,
+    interval: Duration,
+    vmmap_interval: Option<Duration>,
+    cpu_duration: Option<Duration>,
+    cpu_hz: i32,
+    callback_autorelease_pool: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct CounterSnapshot {
+    ui_timer_ticks: u64,
+    menu_will_open: u64,
+    menu_refreshes: u64,
+    driver_status_checks: u64,
+    control_frames: u64,
+    input_reports: u64,
+    hid_open_path_attempts: u64,
+    hid_interface_reopens: u64,
+    hid_interface_reopen_ok: u64,
+    hid_idle_reopen_attempts: u64,
+    hid_idle_reopen_ok: u64,
+    hid_error_reopen_attempts: u64,
+    hid_error_reopen_ok: u64,
+    hid_main_refreshes: u64,
+    hid_main_refresh_ok: u64,
+}
+
+impl CounterSnapshot {
+    fn now() -> Self {
+        Self {
+            ui_timer_ticks: UI_TIMER_TICKS.load(Ordering::Relaxed),
+            menu_will_open: MENU_WILL_OPEN.load(Ordering::Relaxed),
+            menu_refreshes: MENU_REFRESHES.load(Ordering::Relaxed),
+            driver_status_checks: DRIVER_STATUS_CHECKS.load(Ordering::Relaxed),
+            control_frames: CONTROL_FRAMES.load(Ordering::Relaxed),
+            input_reports: INPUT_REPORTS.load(Ordering::Relaxed),
+            hid_open_path_attempts: HID_OPEN_PATH_ATTEMPTS.load(Ordering::Relaxed),
+            hid_interface_reopens: HID_INTERFACE_REOPENS.load(Ordering::Relaxed),
+            hid_interface_reopen_ok: HID_INTERFACE_REOPEN_OK.load(Ordering::Relaxed),
+            hid_idle_reopen_attempts: HID_IDLE_REOPEN_ATTEMPTS.load(Ordering::Relaxed),
+            hid_idle_reopen_ok: HID_IDLE_REOPEN_OK.load(Ordering::Relaxed),
+            hid_error_reopen_attempts: HID_ERROR_REOPEN_ATTEMPTS.load(Ordering::Relaxed),
+            hid_error_reopen_ok: HID_ERROR_REOPEN_OK.load(Ordering::Relaxed),
+            hid_main_refreshes: HID_MAIN_REFRESHES.load(Ordering::Relaxed),
+            hid_main_refresh_ok: HID_MAIN_REFRESH_OK.load(Ordering::Relaxed),
+        }
+    }
+
+    fn delta_since(self, previous: Self) -> Self {
+        Self {
+            ui_timer_ticks: self.ui_timer_ticks.saturating_sub(previous.ui_timer_ticks),
+            menu_will_open: self.menu_will_open.saturating_sub(previous.menu_will_open),
+            menu_refreshes: self.menu_refreshes.saturating_sub(previous.menu_refreshes),
+            driver_status_checks: self
+                .driver_status_checks
+                .saturating_sub(previous.driver_status_checks),
+            control_frames: self.control_frames.saturating_sub(previous.control_frames),
+            input_reports: self.input_reports.saturating_sub(previous.input_reports),
+            hid_open_path_attempts: self
+                .hid_open_path_attempts
+                .saturating_sub(previous.hid_open_path_attempts),
+            hid_interface_reopens: self
+                .hid_interface_reopens
+                .saturating_sub(previous.hid_interface_reopens),
+            hid_interface_reopen_ok: self
+                .hid_interface_reopen_ok
+                .saturating_sub(previous.hid_interface_reopen_ok),
+            hid_idle_reopen_attempts: self
+                .hid_idle_reopen_attempts
+                .saturating_sub(previous.hid_idle_reopen_attempts),
+            hid_idle_reopen_ok: self
+                .hid_idle_reopen_ok
+                .saturating_sub(previous.hid_idle_reopen_ok),
+            hid_error_reopen_attempts: self
+                .hid_error_reopen_attempts
+                .saturating_sub(previous.hid_error_reopen_attempts),
+            hid_error_reopen_ok: self
+                .hid_error_reopen_ok
+                .saturating_sub(previous.hid_error_reopen_ok),
+            hid_main_refreshes: self
+                .hid_main_refreshes
+                .saturating_sub(previous.hid_main_refreshes),
+            hid_main_refresh_ok: self
+                .hid_main_refresh_ok
+                .saturating_sub(previous.hid_main_refresh_ok),
+        }
+    }
+
+    fn format(self) -> String {
+        format!(
+            "ui_timer={} menu_open={} menu_refresh={} driver_status={} control_frames={} input_reports={} hid_open_path={} hid_interface_reopen={}/{} hid_idle_reopen={}/{} hid_error_reopen={}/{} hid_main_refresh={}/{}",
+            self.ui_timer_ticks,
+            self.menu_will_open,
+            self.menu_refreshes,
+            self.driver_status_checks,
+            self.control_frames,
+            self.input_reports,
+            self.hid_open_path_attempts,
+            self.hid_interface_reopen_ok,
+            self.hid_interface_reopens,
+            self.hid_idle_reopen_ok,
+            self.hid_idle_reopen_attempts,
+            self.hid_error_reopen_ok,
+            self.hid_error_reopen_attempts,
+            self.hid_main_refresh_ok,
+            self.hid_main_refreshes
+        )
+    }
+}
+
+pub(crate) fn start_from_env() {
+    let callback_autorelease_pool = env_bool(PROBE_CALLBACK_POOL_ENV);
+    CALLBACK_AUTORELEASE_POOL.store(callback_autorelease_pool, Ordering::Relaxed);
+
+    if !env_bool(PROBE_ENV) {
+        if callback_autorelease_pool {
+            log::info!("CrossPuck probe autorelease pool experiment enabled");
+        }
+        return;
+    }
+    if STARTED
+        .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+        .is_err()
+    {
+        return;
+    }
+
+    let config = ProbeConfig::from_env();
+    if let Err(error) = fs::create_dir_all(&config.dir) {
+        log::warn!(
+            "CrossPuck probe disabled: failed to create {}: {error}",
+            config.dir.display()
+        );
+        return;
+    }
+
+    log::info!(
+        "CrossPuck probe enabled: dir={} interval={}ms vmmap_interval={}ms cpu_seconds={} callback_autorelease_pool={}",
+        config.dir.display(),
+        config.interval.as_millis(),
+        config
+            .vmmap_interval
+            .map(|duration| duration.as_millis().to_string())
+            .unwrap_or_else(|| "disabled".to_string()),
+        config
+            .cpu_duration
+            .map(|duration| duration.as_secs().to_string())
+            .unwrap_or_else(|| "disabled".to_string()),
+        config.callback_autorelease_pool
+    );
+
+    start_cpu_profile(&config);
+    let _ = thread::Builder::new()
+        .name("crosspuck-probe".to_string())
+        .spawn(move || run_probe_loop(config));
+}
+
+pub(crate) fn note_ui_timer_tick() {
+    UI_TIMER_TICKS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_menu_will_open() {
+    MENU_WILL_OPEN.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_menu_refresh() {
+    MENU_REFRESHES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_driver_status_check() {
+    DRIVER_STATUS_CHECKS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_control_frame() {
+    CONTROL_FRAMES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_input_report() {
+    INPUT_REPORTS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_hid_open_path_attempt() {
+    HID_OPEN_PATH_ATTEMPTS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_hid_interface_reopen_attempt() {
+    HID_INTERFACE_REOPENS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_hid_interface_reopen_ok() {
+    HID_INTERFACE_REOPEN_OK.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_hid_error_reopen_attempt() {
+    HID_ERROR_REOPEN_ATTEMPTS.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_hid_error_reopen_ok() {
+    HID_ERROR_REOPEN_OK.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_hid_main_refresh_attempt() {
+    HID_MAIN_REFRESHES.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn note_hid_main_refresh_ok() {
+    HID_MAIN_REFRESH_OK.fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn with_callback_autorelease_pool<T>(body: impl FnOnce() -> T) -> T {
+    if CALLBACK_AUTORELEASE_POOL.load(Ordering::Relaxed) {
+        unsafe {
+            let _pool = NSAutoreleasePool::new();
+            body()
+        }
+    } else {
+        body()
+    }
+}
+
+impl ProbeConfig {
+    fn from_env() -> Self {
+        let pid = process::id();
+        Self {
+            pid,
+            dir: env::var_os(PROBE_DIR_ENV)
+                .map(PathBuf::from)
+                .unwrap_or_else(|| default_probe_dir(pid)),
+            interval: env_duration_ms(PROBE_INTERVAL_MS_ENV).unwrap_or(DEFAULT_PROBE_INTERVAL),
+            vmmap_interval: env_duration_ms(PROBE_VMMAP_INTERVAL_MS_ENV)
+                .or(Some(DEFAULT_VMMAP_INTERVAL))
+                .filter(|duration| !duration.is_zero()),
+            cpu_duration: env_duration_secs(PROBE_CPU_SECONDS_ENV)
+                .filter(|duration| !duration.is_zero()),
+            cpu_hz: env_i32(PROBE_CPU_HZ_ENV).unwrap_or(DEFAULT_CPU_HZ).max(1),
+            callback_autorelease_pool: env_bool(PROBE_CALLBACK_POOL_ENV),
+        }
+    }
+}
+
+fn run_probe_loop(config: ProbeConfig) {
+    let path = config.dir.join("probe.log");
+    let mut file = match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(file) => file,
+        Err(error) => {
+            log::warn!(
+                "CrossPuck probe disabled: failed to open {}: {error}",
+                path.display()
+            );
+            return;
+        }
+    };
+
+    let mut previous = CounterSnapshot::now();
+    let mut previous_rss = current_rss_kb(config.pid);
+    let mut last_vmmap = Instant::now()
+        .checked_sub(config.vmmap_interval.unwrap_or(DEFAULT_VMMAP_INTERVAL))
+        .unwrap_or_else(Instant::now);
+
+    write_probe_line(
+        &mut file,
+        format!(
+            "probe_start pid={} dir={} interval_ms={} vmmap_interval_ms={} cpu_hz={} profiling_feature={} callback_autorelease_pool={}",
+            config.pid,
+            config.dir.display(),
+            config.interval.as_millis(),
+            config
+                .vmmap_interval
+                .map(|duration| duration.as_millis().to_string())
+                .unwrap_or_else(|| "disabled".to_string()),
+            config.cpu_hz,
+            cfg!(feature = "profiling"),
+            config.callback_autorelease_pool
+        ),
+    );
+
+    loop {
+        thread::sleep(config.interval);
+        let now = CounterSnapshot::now();
+        let delta = now.delta_since(previous);
+        previous = now;
+
+        let rss = current_rss_kb(config.pid);
+        let rss_delta = match (rss, previous_rss) {
+            (Some(current), Some(previous)) => current as i64 - previous as i64,
+            _ => 0,
+        };
+        previous_rss = rss.or(previous_rss);
+
+        write_probe_line(
+            &mut file,
+            format!(
+                "probe_tick rss_kb={} rss_delta_kb={} delta=[{}] total=[{}]",
+                rss.map(|value| value.to_string())
+                    .unwrap_or_else(|| "unknown".to_string()),
+                rss_delta,
+                delta.format(),
+                now.format()
+            ),
+        );
+
+        if config
+            .vmmap_interval
+            .is_some_and(|interval| last_vmmap.elapsed() >= interval)
+        {
+            last_vmmap = Instant::now();
+            match vmmap_summary(config.pid) {
+                Some(summary) => write_probe_line(&mut file, format!("probe_vmmap {summary}")),
+                None => write_probe_line(&mut file, "probe_vmmap unavailable".to_string()),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "profiling")]
+fn start_cpu_profile(config: &ProbeConfig) {
+    let Some(duration) = config.cpu_duration else {
+        return;
+    };
+    let pid = config.pid;
+    let dir = config.dir.clone();
+    let hz = config.cpu_hz;
+    let _ = thread::Builder::new()
+        .name("crosspuck-pprof".to_string())
+        .spawn(move || {
+            let output = dir.join(format!("cpu-{pid}-{}s.svg", duration.as_secs()));
+            log::info!(
+                "CrossPuck CPU profiler started: duration={}s hz={} output={}",
+                duration.as_secs(),
+                hz,
+                output.display()
+            );
+
+            let guard = match pprof::ProfilerGuard::new(hz) {
+                Ok(guard) => guard,
+                Err(error) => {
+                    log::warn!("CrossPuck CPU profiler failed to start: {error}");
+                    return;
+                }
+            };
+            thread::sleep(duration);
+
+            let report = match guard.report().build() {
+                Ok(report) => report,
+                Err(error) => {
+                    log::warn!("CrossPuck CPU profiler failed to build report: {error}");
+                    return;
+                }
+            };
+            let file = match File::create(&output) {
+                Ok(file) => file,
+                Err(error) => {
+                    log::warn!(
+                        "CrossPuck CPU profiler failed to create {}: {error}",
+                        output.display()
+                    );
+                    return;
+                }
+            };
+            if let Err(error) = report.flamegraph(file) {
+                log::warn!("CrossPuck CPU profiler failed to write flamegraph: {error}");
+                return;
+            }
+            log::info!("CrossPuck CPU profiler wrote {}", output.display());
+        });
+}
+
+#[cfg(not(feature = "profiling"))]
+fn start_cpu_profile(config: &ProbeConfig) {
+    if config.cpu_duration.is_some() {
+        log::warn!(
+            "CrossPuck CPU profiler requested but this binary was built without --features profiling"
+        );
+    }
+}
+
+fn write_probe_line(file: &mut File, line: String) {
+    log::info!("CrossPuck {line}");
+    let _ = writeln!(file, "{} {line}", unix_timestamp_millis());
+    let _ = file.flush();
+}
+
+fn current_rss_kb(pid: u32) -> Option<u64> {
+    let output = Command::new("/bin/ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u64>()
+        .ok()
+}
+
+fn vmmap_summary(pid: u32) -> Option<String> {
+    let output = Command::new("/usr/bin/vmmap")
+        .args(["-summary", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout);
+    let lines = text
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            line.starts_with("Physical footprint:")
+                || line.starts_with("MALLOC_SMALL")
+                || line.starts_with("MALLOC_TINY")
+                || line.starts_with("MALLOC metadata")
+                || line.starts_with("DefaultMallocZone_")
+                || line.starts_with("TOTAL ")
+        })
+        .map(compact_whitespace)
+        .collect::<Vec<_>>();
+
+    (!lines.is_empty()).then(|| lines.join(" | "))
+}
+
+fn compact_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn default_probe_dir(pid: u32) -> PathBuf {
+    env::temp_dir().join(format!("crosspuck-probe-{pid}"))
+}
+
+fn env_bool(name: &str) -> bool {
+    env::var(name).ok().is_some_and(|value| {
+        matches!(
+            value.to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+fn env_duration_ms(name: &str) -> Option<Duration> {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_millis)
+}
+
+fn env_duration_secs(name: &str) -> Option<Duration> {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+}
+
+fn env_i32(name: &str) -> Option<i32> {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<i32>().ok())
+}
+
+fn unix_timestamp_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}

--- a/crates/crosspuck-app/src/runtime.rs
+++ b/crates/crosspuck-app/src/runtime.rs
@@ -11,6 +11,7 @@ use crosspuck_core::protocol::{
 use crosspuck_core::transport::{
     ChannelStream, TransportAddrs, TransportError, TransportListeners,
 };
+use objc2_foundation::NSAutoreleasePool;
 use sha2::{Digest, Sha256};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -297,7 +298,7 @@ fn refresh_idle_puck_state(listeners: &TransportListeners, app_state: &AppState)
     if listeners.local_addrs().is_err() {
         return;
     }
-    match snapshot_for_filter(&HidFilter::steam_puck()) {
+    match with_worker_autorelease_pool(|| snapshot_for_filter(&HidFilter::steam_puck())) {
         Ok(snapshot) => app_state.set(HostRuntimeState::PuckConnected {
             serial: snapshot.identity.serial,
         }),
@@ -331,22 +332,25 @@ fn handle_session(
         ));
     }
 
-    let snapshot = match snapshot_for_filter(&HidFilter::steam_puck()) {
-        Ok(snapshot) => snapshot,
-        Err(error) => {
-            app_state.set(HostRuntimeState::PuckDisconnected);
-            let hello_ok = hello_ok_with_status(
-                StatusCode::DeviceDisconnected,
-                session_id,
-                session_trace_id,
-                0,
-            );
-            write_payload(control, hello_frame.header.id, &hello_ok)?;
-            return Err(RuntimeError::DeviceUnavailable(error.to_string()));
-        }
-    };
+    let snapshot =
+        match with_worker_autorelease_pool(|| snapshot_for_filter(&HidFilter::steam_puck())) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                app_state.set(HostRuntimeState::PuckDisconnected);
+                let hello_ok = hello_ok_with_status(
+                    StatusCode::DeviceDisconnected,
+                    session_id,
+                    session_trace_id,
+                    0,
+                );
+                write_payload(control, hello_frame.header.id, &hello_ok)?;
+                return Err(RuntimeError::DeviceUnavailable(error.to_string()));
+            }
+        };
     let identity = IdentityPayload::try_from(&snapshot)?;
-    let backend = Arc::new(RealHostBackend::new(snapshot, identity)?);
+    let backend = Arc::new(with_worker_autorelease_pool(|| {
+        RealHostBackend::new(snapshot, identity)
+    })?);
     handle_session_with_backend(
         listeners,
         control,
@@ -470,7 +474,7 @@ fn handle_session_with_backend_timeout(
         run_control_loop(control, backend.as_ref(), session.session_trace_id, stop);
     input_running.store(false, Ordering::Relaxed);
     let _ = input_thread.join();
-    backend.cleanup_feedback();
+    with_worker_autorelease_pool(|| backend.cleanup_feedback());
     set_host_log_session_trace_id(None);
     app_state.set(HostRuntimeState::PuckConnected {
         serial: identity.serial,
@@ -495,65 +499,69 @@ fn run_control_loop(
             Err(error) if is_timeout_or_would_block(&error) => continue,
             Err(error) => return Err(error.into()),
         };
+        crate::probe::note_control_frame();
 
-        match frame.header.message_type {
-            MessageType::GetFeature => {
-                let request = GetFeature::decode(&frame.payload)?;
-                let result = backend.get_feature(&request);
-                if !result.status.is_ok() {
-                    log::warn!(
-                        "CrossPuck[{session_trace}] GET_FEATURE id={} interface={} report_id=0x{:02X} status={}",
-                        frame.header.id, request.interface_number, request.report_id, result.status
-                    );
+        with_worker_autorelease_pool(|| -> Result<(), RuntimeError> {
+            match frame.header.message_type {
+                MessageType::GetFeature => {
+                    let request = GetFeature::decode(&frame.payload)?;
+                    let result = backend.get_feature(&request);
+                    if !result.status.is_ok() {
+                        log::warn!(
+                            "CrossPuck[{session_trace}] GET_FEATURE id={} interface={} report_id=0x{:02X} status={}",
+                            frame.header.id, request.interface_number, request.report_id, result.status
+                        );
+                    }
+                    write_payload(control, frame.header.id, &result)?;
                 }
-                write_payload(control, frame.header.id, &result)?;
-            }
-            MessageType::SetFeature => {
-                let request = SetFeature::decode(&frame.payload)?;
-                let result = backend.set_feature(&request);
-                if !result.status.is_ok() {
-                    log::warn!(
-                        "CrossPuck[{session_trace}] SET_FEATURE id={} interface={} len={} status={}",
-                        frame.header.id,
-                        request.interface_number,
-                        request.data.len(),
-                        result.status
-                    );
+                MessageType::SetFeature => {
+                    let request = SetFeature::decode(&frame.payload)?;
+                    let result = backend.set_feature(&request);
+                    if !result.status.is_ok() {
+                        log::warn!(
+                            "CrossPuck[{session_trace}] SET_FEATURE id={} interface={} len={} status={}",
+                            frame.header.id,
+                            request.interface_number,
+                            request.data.len(),
+                            result.status
+                        );
+                    }
+                    write_payload(control, frame.header.id, &result)?;
                 }
-                write_payload(control, frame.header.id, &result)?;
-            }
-            MessageType::SetOutput => {
-                let request = SetOutput::decode(&frame.payload)?;
-                let result = backend.set_output(&request);
-                if !result.status.is_ok() {
-                    log::warn!(
-                        "CrossPuck[{session_trace}] SET_OUTPUT id={} interface={} len={} status={}",
-                        frame.header.id,
-                        request.interface_number,
-                        request.data.len(),
-                        result.status
-                    );
+                MessageType::SetOutput => {
+                    let request = SetOutput::decode(&frame.payload)?;
+                    let result = backend.set_output(&request);
+                    if !result.status.is_ok() {
+                        log::warn!(
+                            "CrossPuck[{session_trace}] SET_OUTPUT id={} interface={} len={} status={}",
+                            frame.header.id,
+                            request.interface_number,
+                            request.data.len(),
+                            result.status
+                        );
+                    }
+                    write_payload(control, frame.header.id, &result)?;
                 }
-                write_payload(control, frame.header.id, &result)?;
-            }
-            MessageType::Write => {
-                let request = WriteReport::decode(&frame.payload)?;
-                let result = backend.write_report(&request);
-                if !result.status.is_ok() {
-                    log::warn!(
-                        "CrossPuck[{session_trace}] WRITE id={} interface={} len={} status={}",
-                        frame.header.id,
-                        request.interface_number,
-                        request.data.len(),
-                        result.status
-                    );
+                MessageType::Write => {
+                    let request = WriteReport::decode(&frame.payload)?;
+                    let result = backend.write_report(&request);
+                    if !result.status.is_ok() {
+                        log::warn!(
+                            "CrossPuck[{session_trace}] WRITE id={} interface={} len={} status={}",
+                            frame.header.id,
+                            request.interface_number,
+                            request.data.len(),
+                            result.status
+                        );
+                    }
+                    write_payload(control, frame.header.id, &result)?;
                 }
-                write_payload(control, frame.header.id, &result)?;
+                actual => {
+                    return Err(RuntimeError::UnexpectedControlMessage(actual));
+                }
             }
-            actual => {
-                return Err(RuntimeError::UnexpectedControlMessage(actual));
-            }
-        }
+            Ok(())
+        })?;
     }
 }
 
@@ -640,16 +648,17 @@ fn spawn_input_stream(
     running: Arc<AtomicBool>,
 ) -> Result<JoinHandle<()>, RuntimeError> {
     Ok(thread::spawn(move || {
-        let Ok(mut reader) = backend.open_input_reader() else {
+        let Ok(mut reader) = with_worker_autorelease_pool(|| backend.open_input_reader()) else {
             return;
         };
         let start = Instant::now();
         let mut sequence = 1_u32;
 
         while running.load(Ordering::Relaxed) {
-            match reader.read_report(Duration::from_millis(10)) {
+            match with_worker_autorelease_pool(|| reader.read_report(Duration::from_millis(10))) {
                 Ok(None) => {}
                 Ok(Some(input_report)) => {
+                    crate::probe::note_input_report();
                     let report = InputReport {
                         interface_number: input_report.descriptor.interface_number,
                         role: input_report.descriptor.role,
@@ -666,6 +675,13 @@ fn spawn_input_stream(
             }
         }
     }))
+}
+
+fn with_worker_autorelease_pool<T>(body: impl FnOnce() -> T) -> T {
+    unsafe {
+        let _pool = NSAutoreleasePool::new();
+        body()
+    }
 }
 
 fn hello_ok_with_status(

--- a/tools/README.md
+++ b/tools/README.md
@@ -100,6 +100,38 @@ cargo check -p crosspuck-driver --target x86_64-pc-windows-msvc
 cargo clippy -p crosspuck-driver --target x86_64-pc-windows-msvc -- -D warnings
 ```
 
+## Host App Memory Profiling
+
+Run the macOS host app through `cargo run` with the profiling feature and app
+probe enabled:
+
+```sh
+tools/profile-app.sh
+```
+
+By default this writes a capture under `captures/app-profile/YYYYMMDD-HHMMSS`,
+samples RSS and probe counters every 5 seconds, records `vmmap -summary` every
+30 seconds, and writes a 60-second pprof flamegraph.
+
+Useful options:
+
+```sh
+tools/profile-app.sh --dir /tmp/crosspuck-profile --cpu-seconds 120
+tools/profile-app.sh --release --interval-ms 1000 --vmmap-interval-ms 10000
+tools/profile-app.sh -- --override-log-level --log-level debug
+```
+
+After reproducing idle or touchpad-input scenarios, summarize the capture:
+
+```sh
+tools/profile-app-summary.sh --dir /tmp/crosspuck-profile
+tools/profile-app-summary.sh --dir /tmp/crosspuck-profile --leaks
+```
+
+The summary reports RSS deltas, post-warmup deltas, CrossPuck probe counters,
+the latest captured `vmmap` line, any generated CPU flamegraphs, and live
+`ps`/`vmmap` data if the process is still running.
+
 ## macOS HID Reference Probe
 
 The macOS HID reference probe is a host-side reference tracer for the native

--- a/tools/build-app.sh
+++ b/tools/build-app.sh
@@ -5,6 +5,7 @@ profile="${1:-debug}"
 root_dir="$(cd "$(dirname "$0")/.." && pwd)"
 driver_target="x86_64-pc-windows-gnu"
 driver_profile="release"
+app_features="${CROSSPUCK_APP_FEATURES:-}"
 
 ensure_driver_target_installed() {
   if ! command -v rustup >/dev/null 2>&1; then
@@ -58,8 +59,13 @@ cargo build \
   --release \
   --target "$driver_target"
 
-# shellcheck disable=SC2086
-cargo build --manifest-path "$root_dir/Cargo.toml" -p crosspuck-app $app_cargo_args
+if [ -n "$app_features" ]; then
+  # shellcheck disable=SC2086
+  cargo build --manifest-path "$root_dir/Cargo.toml" -p crosspuck-app $app_cargo_args --features "$app_features"
+else
+  # shellcheck disable=SC2086
+  cargo build --manifest-path "$root_dir/Cargo.toml" -p crosspuck-app $app_cargo_args
+fi
 
 driver_dll="$root_dir/target/$driver_target/$driver_profile/hid.dll"
 if [ ! -f "$driver_dll" ]; then

--- a/tools/profile-app-summary.sh
+++ b/tools/profile-app-summary.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/profile-app-summary.sh [--dir PATH | --log PATH] [options]
+
+Summarizes a CrossPuck app profiling capture produced by tools/profile-app.sh.
+
+Options:
+  --dir PATH           Capture directory containing probe.log.
+  --log PATH           Explicit probe.log path.
+  --pid PID            Override PID from probe_start.
+  --warmup-ticks N     Exclude the first N probe_tick rows from warmup summary.
+                       Default: 2
+  --leaks              Run macOS leaks against the live process.
+  --help, -h           Show this help.
+
+Examples:
+  tools/profile-app-summary.sh --dir captures/app-profile/20260528-210000
+  tools/profile-app-summary.sh --log /tmp/crosspuck-probe/probe.log --pid 12345
+USAGE
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+
+capture_dir=""
+probe_log=""
+pid=""
+warmup_ticks="2"
+run_leaks="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir)
+      capture_dir="${2:?missing value for --dir}"
+      shift 2
+      ;;
+    --log)
+      probe_log="${2:?missing value for --log}"
+      shift 2
+      ;;
+    --pid)
+      pid="${2:?missing value for --pid}"
+      shift 2
+      ;;
+    --warmup-ticks)
+      warmup_ticks="${2:?missing value for --warmup-ticks}"
+      shift 2
+      ;;
+    --leaks)
+      run_leaks="1"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$probe_log" ]]; then
+  if [[ -z "$capture_dir" ]]; then
+    latest_dir="$(find "$root_dir/captures/app-profile" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | tail -n 1 || true)"
+    if [[ -n "$latest_dir" ]]; then
+      capture_dir="$latest_dir"
+    else
+      echo "No capture directory given and no captures/app-profile directory found." >&2
+      usage >&2
+      exit 2
+    fi
+  fi
+  probe_log="$capture_dir/probe.log"
+else
+  capture_dir="$(dirname "$probe_log")"
+fi
+
+if [[ ! -f "$probe_log" ]]; then
+  echo "probe.log not found: $probe_log" >&2
+  exit 1
+fi
+
+if [[ -z "$pid" ]]; then
+  pid="$(sed -nE 's/.*probe_start pid=([0-9]+).*/\1/p' "$probe_log" | tail -n 1)"
+fi
+
+echo "CrossPuck profiling summary"
+echo "Capture: $capture_dir"
+echo "Probe log: $probe_log"
+if [[ -n "$pid" ]]; then
+  echo "PID: $pid"
+fi
+echo
+
+awk -v warmup="$warmup_ticks" '
+function value(line, key,    pattern, start, rest) {
+  pattern = key "="
+  start = index(line, pattern)
+  if (start == 0) {
+    return ""
+  }
+  rest = substr(line, start + length(pattern))
+  sub(/[^0-9-].*/, "", rest)
+  return rest
+}
+function add_counter(line, name, key,    found) {
+  found = value(line, key)
+  if (found != "") {
+    counter[name] += found
+    if (tick > warmup) {
+      warm_counter[name] += found
+    }
+  }
+}
+/probe_tick / {
+  tick++
+  rss = value($0, "rss_kb")
+  rss_delta = value($0, "rss_delta_kb")
+  if (rss != "") {
+    if (first_rss == "") {
+      first_rss = rss
+    }
+    last_rss = rss
+    if (min_rss == "" || rss < min_rss) {
+      min_rss = rss
+    }
+    if (max_rss == "" || rss > max_rss) {
+      max_rss = rss
+    }
+    if (tick == warmup + 1) {
+      warm_first_rss = rss
+    }
+    if (tick > warmup) {
+      warm_last_rss = rss
+      warm_ticks++
+    }
+  }
+  if (rss_delta != "") {
+    rss_delta_sum += rss_delta
+    if (tick > warmup) {
+      warm_rss_delta_sum += rss_delta
+    }
+  }
+  add_counter($0, "ui_timer", "ui_timer")
+  add_counter($0, "menu_open", "menu_open")
+  add_counter($0, "menu_refresh", "menu_refresh")
+  add_counter($0, "driver_status", "driver_status")
+  add_counter($0, "control_frames", "control_frames")
+  add_counter($0, "input_reports", "input_reports")
+  add_counter($0, "hid_open_path", "hid_open_path")
+  add_counter($0, "hid_interface_reopen_ok", "hid_interface_reopen")
+  add_counter($0, "hid_error_reopen_ok", "hid_error_reopen")
+  add_counter($0, "hid_main_refresh_ok", "hid_main_refresh")
+}
+END {
+  if (tick == 0) {
+    print "No probe_tick rows found."
+    exit
+  }
+  printf("ticks=%d first_rss_kb=%s last_rss_kb=%s min_rss_kb=%s max_rss_kb=%s rss_delta_sum_kb=%d\n",
+    tick, first_rss, last_rss, min_rss, max_rss, rss_delta_sum)
+  if (warm_ticks > 0) {
+    printf("after_warmup_ticks=%d warmup_ticks=%d first_rss_kb=%s last_rss_kb=%s rss_delta_sum_kb=%d\n",
+      warm_ticks, warmup, warm_first_rss, warm_last_rss, warm_rss_delta_sum)
+  }
+  printf("counter_delta control_frames=%d input_reports=%d hid_open_path=%d hid_interface_reopen_ok=%d hid_error_reopen_ok=%d hid_main_refresh_ok=%d menu_refresh=%d driver_status=%d ui_timer=%d menu_open=%d\n",
+    counter["control_frames"], counter["input_reports"], counter["hid_open_path"],
+    counter["hid_interface_reopen_ok"], counter["hid_error_reopen_ok"],
+    counter["hid_main_refresh_ok"], counter["menu_refresh"], counter["driver_status"],
+    counter["ui_timer"], counter["menu_open"])
+  if (warm_ticks > 0) {
+    printf("after_warmup_counter_delta control_frames=%d input_reports=%d hid_open_path=%d hid_interface_reopen_ok=%d hid_error_reopen_ok=%d hid_main_refresh_ok=%d menu_refresh=%d driver_status=%d ui_timer=%d menu_open=%d\n",
+      warm_counter["control_frames"], warm_counter["input_reports"], warm_counter["hid_open_path"],
+      warm_counter["hid_interface_reopen_ok"], warm_counter["hid_error_reopen_ok"],
+      warm_counter["hid_main_refresh_ok"], warm_counter["menu_refresh"], warm_counter["driver_status"],
+      warm_counter["ui_timer"], warm_counter["menu_open"])
+  }
+}
+' "$probe_log"
+
+latest_vmmap="$(grep 'probe_vmmap ' "$probe_log" | tail -n 1 || true)"
+if [[ -n "$latest_vmmap" ]]; then
+  echo
+  echo "Latest probe vmmap summary:"
+  echo "$latest_vmmap"
+fi
+
+echo
+echo "CPU flamegraphs:"
+find "$capture_dir" -maxdepth 1 -type f -name 'cpu-*.svg' -print | sort || true
+
+if [[ -n "$pid" ]] && ps -p "$pid" >/dev/null 2>&1; then
+  echo
+  echo "Live process:"
+  ps -o pid,rss,vsz,etime,command -p "$pid"
+
+  if command -v vmmap >/dev/null 2>&1; then
+    echo
+    echo "Live vmmap summary:"
+    vmmap -summary "$pid" 2>/dev/null \
+      | awk '
+          /^[[:space:]]*Physical footprint:/ ||
+          /^[[:space:]]*MALLOC_SMALL/ ||
+          /^[[:space:]]*MALLOC_TINY/ ||
+          /^[[:space:]]*MALLOC metadata/ ||
+          /^[[:space:]]*DefaultMallocZone_/ ||
+          /^[[:space:]]*TOTAL / { gsub(/[[:space:]]+/, " "); print }
+        ' || true
+  fi
+
+  if [[ "$run_leaks" == "1" ]]; then
+    echo
+    echo "Live leaks result:"
+    leaks "$pid" || true
+  fi
+else
+  echo
+  echo "Live process is not running; pass --pid for an active process if needed."
+fi

--- a/tools/profile-app.sh
+++ b/tools/profile-app.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/profile-app.sh [options] [-- app args...]
+
+Runs CrossPuck with the profiling feature enabled and writes probe output to a
+reproducible capture directory.
+
+Options:
+  --dir PATH                 Capture directory.
+                             Default: captures/app-profile/YYYYMMDD-HHMMSS
+  --release                  Run the app with cargo --release.
+  --interval-ms N            RSS/counter sample interval. Default: 5000
+  --vmmap-interval-ms N      vmmap summary interval. Default: 30000
+                             Use 0 to disable vmmap snapshots.
+  --cpu-seconds N            pprof CPU flamegraph duration. Default: 60
+                             Use 0 to disable CPU profiling.
+  --cpu-hz N                 pprof sample frequency. Default: 99
+  --callback-pool            Enable the callback autorelease-pool experiment.
+  --log-level LEVEL          Host log level via CROSSPUCK_LOG_LEVEL.
+                             Default: info
+  --help, -h                 Show this help.
+
+Examples:
+  tools/profile-app.sh
+  tools/profile-app.sh --dir /tmp/crosspuck-profile --cpu-seconds 120
+  tools/profile-app.sh --release -- --override-log-level --log-level debug
+
+Artifacts:
+  probe.log                  RSS, vmmap summaries, and CrossPuck counters.
+  cpu-<pid>-<seconds>s.svg   pprof flamegraph, when --cpu-seconds is non-zero.
+
+After reproducing a scenario, summarize the capture with:
+  tools/profile-app-summary.sh --dir <capture-dir>
+USAGE
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+timestamp="$(date +%Y%m%d-%H%M%S)"
+
+capture_dir="$root_dir/captures/app-profile/$timestamp"
+cargo_profile_args=()
+interval_ms="5000"
+vmmap_interval_ms="30000"
+cpu_seconds="60"
+cpu_hz="99"
+callback_pool="0"
+log_level="${CROSSPUCK_LOG_LEVEL:-info}"
+app_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir)
+      capture_dir="${2:?missing value for --dir}"
+      shift 2
+      ;;
+    --release)
+      cargo_profile_args+=(--release)
+      shift
+      ;;
+    --interval-ms)
+      interval_ms="${2:?missing value for --interval-ms}"
+      shift 2
+      ;;
+    --vmmap-interval-ms)
+      vmmap_interval_ms="${2:?missing value for --vmmap-interval-ms}"
+      shift 2
+      ;;
+    --cpu-seconds)
+      cpu_seconds="${2:?missing value for --cpu-seconds}"
+      shift 2
+      ;;
+    --cpu-hz)
+      cpu_hz="${2:?missing value for --cpu-hz}"
+      shift 2
+      ;;
+    --callback-pool)
+      callback_pool="1"
+      shift
+      ;;
+    --log-level)
+      log_level="${2:?missing value for --log-level}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      app_args=("$@")
+      break
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$capture_dir"
+
+cat >"$capture_dir/profile-env.txt" <<EOF
+CROSSPUCK_PROBE=1
+CROSSPUCK_PROBE_DIR=$capture_dir
+CROSSPUCK_PROBE_INTERVAL_MS=$interval_ms
+CROSSPUCK_PROBE_VMMAP_INTERVAL_MS=$vmmap_interval_ms
+CROSSPUCK_PROBE_CPU_SECONDS=$cpu_seconds
+CROSSPUCK_PROBE_CPU_HZ=$cpu_hz
+CROSSPUCK_PROBE_AUTORELEASE_POOL=$callback_pool
+CROSSPUCK_LOG_LEVEL=$log_level
+EOF
+
+cat <<EOF
+CrossPuck profiling run
+Capture: $capture_dir
+Probe log: $capture_dir/probe.log
+CPU flamegraph: $capture_dir/cpu-<pid>-${cpu_seconds}s.svg
+
+Run summary after quitting the app:
+  tools/profile-app-summary.sh --dir "$capture_dir"
+EOF
+
+export CROSSPUCK_PROBE=1
+export CROSSPUCK_PROBE_DIR="$capture_dir"
+export CROSSPUCK_PROBE_INTERVAL_MS="$interval_ms"
+export CROSSPUCK_PROBE_VMMAP_INTERVAL_MS="$vmmap_interval_ms"
+export CROSSPUCK_PROBE_CPU_SECONDS="$cpu_seconds"
+export CROSSPUCK_PROBE_CPU_HZ="$cpu_hz"
+export CROSSPUCK_PROBE_AUTORELEASE_POOL="$callback_pool"
+export CROSSPUCK_LOG_LEVEL="$log_level"
+
+exec cargo run \
+  --manifest-path "$root_dir/Cargo.toml" \
+  -p crosspuck-app \
+  --features profiling \
+  --bin CrossPuck \
+  "${cargo_profile_args[@]}" \
+  -- \
+  "${app_args[@]}"


### PR DESCRIPTION
## Summary

This PR fixes the CrossPuck host app memory growth observed during idle and high-frequency Steam Controller input, especially touchpad movement.

The main fixes are:

- Stop reopening the main HID device on normal idle read timeouts.
- Wrap HID worker-thread macOS/IOKit work in `NSAutoreleasePool`.
- Cache non-main HID interface devices instead of reopening them per control frame.
- Add feature-gated profiling support behind the `profiling` Cargo feature.
- Add reproducible profiling scripts under `tools/`.

## Details

Profiling showed that memory growth was amplified by two paths:

1. Normal no-data HID reads were treated too aggressively and could trigger repeated reopen behavior.
2. Touchpad/control-heavy traffic caused repeated HID open paths for non-main interfaces.

This PR changes the host HID backend so that:

- idle/no-data reads return `Ok(None)` without reopening the device;
- actual HID errors still use the existing reopen path;
- interface-specific HID devices are cached and reopened only on real failure;
- worker loops that call into macOS HID/IOKit APIs run inside autorelease pools