### PR TITLE
Harden CrossOver driver startup and install flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "crosspuck-app"
-version = "0.3.0"
+version = "0.3.1-rc0"
 dependencies = [
  "crosspuck-core",
  "log",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "crosspuck-cli"
-version = "0.3.0"
+version = "0.3.1-rc0"
 dependencies = [
  "crosspuck-core",
  "hidapi",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "crosspuck-core"
-version = "0.3.0"
+version = "0.3.1-rc0"
 dependencies = [
  "hidapi",
  "serde",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "crosspuck-driver"
-version = "0.3.0"
+version = "0.3.1-rc0"
 dependencies = [
  "crosspuck-core",
  "min_hook_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1-rc0"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Seonghwan Jeong <scryner@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -185,11 +185,16 @@ install/update/uninstall automatically, and install/update/repair import the
 Wine loader override registry file as described above. The shell installer
 below is mainly for manual development and smoke testing.
 
-Install the driver next to `Steam.exe` in the target bottle and import the Wine
-loader override:
+Copy the driver next to `Steam.exe` in the target bottle:
 
 ```sh
 tools/install-driver.sh --bottle Steam
+```
+
+To also import Wine's `hid=native,builtin` loader override:
+
+```sh
+tools/install-driver.sh --bottle Steam --override-dll
 ```
 
 Useful options:
@@ -202,11 +207,11 @@ tools/install-driver.sh \
 ```
 
 The script copies `hid.dll`, backs up any existing local `hid.dll`, and
-initializes `crosspuck-driver.log`. It also writes
-`crosspuck-wine-override.reg` into the bottle and imports it with the matching
-CrossOver app, using CrossOver Preview first for preview-marked bottles and
-CrossOver first for regular bottles. It does not set guest runtime options or
-rewrite `user.reg` directly.
+initializes `crosspuck-driver.log`. By default it does not call CrossOver
+`regedit`. With `--override-dll`, it writes `crosspuck-wine-override.reg` into
+the bottle and imports it with the matching CrossOver app, using CrossOver
+Preview first for preview-marked bottles and CrossOver first for regular
+bottles. It does not set guest runtime options or rewrite `user.reg` directly.
 
 Do not install this DLL into `drive_c/windows/system32`. It is designed to live
 next to Steam and forward non-virtual HID calls to the real system HID DLL.

--- a/crates/crosspuck-app/src/hid_backend.rs
+++ b/crates/crosspuck-app/src/hid_backend.rs
@@ -3,8 +3,8 @@ use crosspuck_core::hid::{
     HidFilter, HidSnapshotError, PuckSnapshot,
 };
 use crosspuck_core::protocol::{
-    session_trace_label, CollectionRole, FeatureResult, GetFeature, IdentityPayload, SetFeature,
-    SetFeatureResult, SetOutput, SetOutputResult, StatusCode, WriteReport, WriteResult,
+    session_trace_label, CollectionRole, FeatureResult, GetFeature, SetFeature, SetFeatureResult,
+    SetOutput, SetOutputResult, StatusCode, WriteReport, WriteResult,
 };
 use std::collections::BTreeMap;
 use std::fmt;
@@ -51,7 +51,6 @@ fn log_host_guest_warning(args: std::fmt::Arguments<'_>) {
 }
 
 pub(crate) trait HostBackend: Send + Sync {
-    fn identity(&self) -> &IdentityPayload;
     fn open_input_reader(&self) -> Result<Box<dyn InputReportReader>, HostHidError>;
     fn get_feature(&self, request: &GetFeature) -> FeatureResult;
     fn set_feature(&self, request: &SetFeature) -> SetFeatureResult;
@@ -79,7 +78,6 @@ pub(crate) struct HostInputReport {
 #[derive(Clone, Debug)]
 pub(crate) struct RealHostBackend {
     snapshot: Arc<Mutex<PuckSnapshot>>,
-    identity: IdentityPayload,
     main: SharedMainDevice,
     interface_devices: Arc<Mutex<BTreeMap<u8, CachedInterfaceDevice>>>,
 }
@@ -98,11 +96,10 @@ struct CachedInterfaceDevice {
 }
 
 impl RealHostBackend {
-    pub fn new(snapshot: PuckSnapshot, identity: IdentityPayload) -> Result<Self, HostHidError> {
+    pub fn new(snapshot: PuckSnapshot) -> Result<Self, HostHidError> {
         let main = Self::open_main_device(&snapshot)?;
         Ok(Self {
             snapshot: Arc::new(Mutex::new(snapshot)),
-            identity,
             main,
             interface_devices: Arc::new(Mutex::new(BTreeMap::new())),
         })
@@ -427,10 +424,6 @@ impl RealHostBackend {
 }
 
 impl HostBackend for RealHostBackend {
-    fn identity(&self) -> &IdentityPayload {
-        &self.identity
-    }
-
     fn open_input_reader(&self) -> Result<Box<dyn InputReportReader>, HostHidError> {
         let readers = self.open_input_devices();
         if readers.is_empty() {
@@ -1006,9 +999,17 @@ impl fmt::Display for HostHidError {
                 write!(f, "invalid HID interface number: {interface_number}")
             }
             Self::DeviceLockPoisoned => write!(f, "HID device lock poisoned"),
+            Self::Hid(error) if is_macos_hid_permission_error(error) => write!(
+                f,
+                "{error}; macOS denied HID access. Run CrossPuck as an app bundle and enable Privacy & Security > Input Monitoring for CrossPuck."
+            ),
             Self::Hid(error) => write!(f, "{error}"),
         }
     }
+}
+
+fn is_macos_hid_permission_error(error: &HidSnapshotError) -> bool {
+    matches!(error, HidSnapshotError::Hid(_)) && error.to_string().contains("0xE00002E2")
 }
 
 impl std::error::Error for HostHidError {

--- a/crates/crosspuck-app/src/runtime.rs
+++ b/crates/crosspuck-app/src/runtime.rs
@@ -350,23 +350,33 @@ fn handle_session(
             }
         };
     let identity = IdentityPayload::try_from(&snapshot)?;
-    let backend = Arc::new(with_worker_autorelease_pool(|| {
-        RealHostBackend::new(snapshot, identity)
-    })?);
-    handle_session_with_backend(
-        listeners,
-        control,
-        SessionStart {
-            session_id,
-            session_trace_id,
-            guest_runtime_overrides,
-            hello_request_id: hello_frame.header.id,
-            guest_pid: hello.guest_pid,
-        },
-        app_state,
-        backend,
-        stop,
-    )
+    let session = SessionStart {
+        session_id,
+        session_trace_id,
+        guest_runtime_overrides,
+        hello_request_id: hello_frame.header.id,
+        guest_pid: hello.guest_pid,
+    };
+    app_state.set(HostRuntimeState::PuckConnected {
+        serial: identity.serial.clone(),
+    });
+    let backend = match with_worker_autorelease_pool(|| RealHostBackend::new(snapshot)) {
+        Ok(backend) => Arc::new(backend),
+        Err(error) => {
+            let hello_ok = hello_ok_with_status(
+                StatusCode::DeviceDisconnected,
+                session_id,
+                session_trace_id,
+                identity.default_input_report_len(),
+            );
+            write_payload(control, hello_frame.header.id, &hello_ok)?;
+            return Err(error.into());
+        }
+    };
+    write_session_preamble(control, &session, &identity)?;
+    let input =
+        attach_input_for_session(listeners, stop, INPUT_ATTACH_TIMEOUT, &session, &identity)?;
+    run_attached_session(control, input, session, app_state, backend, stop, identity)
 }
 
 #[derive(Clone, Debug)]
@@ -378,11 +388,13 @@ struct SessionStart {
     guest_pid: u32,
 }
 
+#[cfg(test)]
 fn handle_session_with_backend(
     listeners: &TransportListeners,
     control: &mut ChannelStream,
     session: SessionStart,
     app_state: &AppState,
+    identity: IdentityPayload,
     backend: Arc<dyn HostBackend>,
     stop: &Arc<AtomicBool>,
 ) -> Result<(), RuntimeError> {
@@ -391,26 +403,39 @@ fn handle_session_with_backend(
         control,
         session,
         app_state,
+        identity,
         backend,
         stop,
         INPUT_ATTACH_TIMEOUT,
     )
 }
 
+#[cfg(test)]
 fn handle_session_with_backend_timeout(
     listeners: &TransportListeners,
     control: &mut ChannelStream,
     session: SessionStart,
     app_state: &AppState,
+    identity: IdentityPayload,
     backend: Arc<dyn HostBackend>,
     stop: &Arc<AtomicBool>,
     input_attach_timeout: Duration,
 ) -> Result<(), RuntimeError> {
-    let identity = backend.identity().clone();
     app_state.set(HostRuntimeState::PuckConnected {
         serial: identity.serial.clone(),
     });
 
+    write_session_preamble(control, &session, &identity)?;
+    let input =
+        attach_input_for_session(listeners, stop, input_attach_timeout, &session, &identity)?;
+    run_attached_session(control, input, session, app_state, backend, stop, identity)
+}
+
+fn write_session_preamble(
+    control: &mut ChannelStream,
+    session: &SessionStart,
+    identity: &IdentityPayload,
+) -> Result<(), RuntimeError> {
     write_payload(
         control,
         session.hello_request_id,
@@ -428,8 +453,17 @@ fn handle_session_with_backend_timeout(
             log_level.as_str()
         );
     }
-    write_payload(control, 0, &identity)?;
+    write_payload(control, 0, identity)?;
+    Ok(())
+}
 
+fn attach_input_for_session(
+    listeners: &TransportListeners,
+    stop: &Arc<AtomicBool>,
+    input_attach_timeout: Duration,
+    session: &SessionStart,
+    identity: &IdentityPayload,
+) -> Result<ChannelStream, RuntimeError> {
     let mut input = accept_input_for_session(listeners, stop, input_attach_timeout)?;
     input.set_write_timeout(Some(Duration::from_millis(250)))?;
     input.set_read_timeout(Some(Duration::from_millis(250)))?;
@@ -461,7 +495,18 @@ fn handle_session_with_backend_timeout(
             actual: attach.session_id,
         });
     }
+    Ok(input)
+}
 
+fn run_attached_session(
+    control: &mut ChannelStream,
+    input: ChannelStream,
+    session: SessionStart,
+    app_state: &AppState,
+    backend: Arc<dyn HostBackend>,
+    stop: &Arc<AtomicBool>,
+    identity: IdentityPayload,
+) -> Result<(), RuntimeError> {
     app_state.set(HostRuntimeState::GuestConnected {
         session_id: session.session_id,
         session_trace_id: session.session_trace_id,
@@ -812,7 +857,6 @@ mod tests {
 
     #[derive(Clone)]
     struct FakeBackend {
-        identity: IdentityPayload,
         reports: Arc<Mutex<VecDeque<Vec<u8>>>>,
         operations: Arc<Mutex<Vec<String>>>,
         cleanup_called: Arc<AtomicBool>,
@@ -821,7 +865,6 @@ mod tests {
     impl FakeBackend {
         fn new(reports: Vec<Vec<u8>>) -> Self {
             Self {
-                identity: test_identity(),
                 reports: Arc::new(Mutex::new(reports.into())),
                 operations: Arc::new(Mutex::new(Vec::new())),
                 cleanup_called: Arc::new(AtomicBool::new(false)),
@@ -842,10 +885,6 @@ mod tests {
     }
 
     impl HostBackend for FakeBackend {
-        fn identity(&self) -> &IdentityPayload {
-            &self.identity
-        }
-
         fn open_input_reader(&self) -> Result<Box<dyn InputReportReader>, HostHidError> {
             Ok(Box::new(FakeInputReader {
                 reports: Arc::clone(&self.reports),
@@ -949,6 +988,7 @@ mod tests {
                     guest_pid: 1234,
                 },
                 &AppState::new(),
+                test_identity(),
                 Arc::new(backend_for_server),
                 &server_stop,
             )
@@ -1034,6 +1074,7 @@ mod tests {
                         guest_pid: 1234,
                     },
                     &AppState::new(),
+                    test_identity(),
                     Arc::new(backend),
                     &server_stop,
                 )
@@ -1081,6 +1122,7 @@ mod tests {
                     guest_pid: 1234,
                 },
                 &AppState::new(),
+                test_identity(),
                 Arc::new(backend),
                 &server_stop,
             );
@@ -1142,6 +1184,7 @@ mod tests {
                     guest_pid: 1234,
                 },
                 &AppState::new(),
+                test_identity(),
                 Arc::new(backend),
                 &server_stop,
                 Duration::from_millis(100),

--- a/crates/crosspuck-driver/docs/crossover-smoke-ko.md
+++ b/crates/crosspuck-driver/docs/crossover-smoke-ko.md
@@ -46,7 +46,7 @@ Steam이 실행 중이면 완전히 종료합니다.
 기본 Steam bottle을 사용하면:
 
 ```sh
-tools/install-driver.sh --bottle Steam
+tools/install-driver.sh --bottle Steam --override-dll
 ```
 
 DLL 경로를 직접 지정하려면:
@@ -55,6 +55,7 @@ DLL 경로를 직접 지정하려면:
 tools/install-driver.sh \
   --bottle Steam \
   --driver target/x86_64-pc-windows-gnu/release/hid.dll \
+  --override-dll \
   --no-build
 ```
 
@@ -64,8 +65,8 @@ tools/install-driver.sh \
 - `steam.exe`와 같은 디렉터리에 `hid.dll`을 복사합니다.
 - 기존 `hid.dll`이 있으면 `crosspuck-backups/` 아래에 백업합니다.
 - Steam 디렉터리에 `crosspuck-driver.log`를 초기화합니다.
-- bottle에 `crosspuck-wine-override.reg`를 생성하고 CrossOver `regedit`로
-  import합니다.
+- `--override-dll`을 지정한 경우에만 bottle에 `crosspuck-wine-override.reg`를
+  생성하고 CrossOver `regedit`로 import합니다.
 - guest runtime용 `CROSSPUCK_*` registry/environment 값은 쓰지 않습니다.
   runtime 설정은 기본값을 쓰고, override가 필요한 값은 macOS host app이
   bridge connection으로 전달합니다.
@@ -80,8 +81,8 @@ drive_c/windows/system32/hid.dll
 
 ## 3. Wine loader override
 
-설치 스크립트는 loader-only Wine override 파일을 자동으로 생성하고
-import합니다.
+설치 스크립트는 `--override-dll`을 지정했을 때만 loader-only Wine override
+파일을 생성하고 import합니다.
 
 생성 후 bottle에 남는 registry 파일:
 
@@ -138,7 +139,6 @@ CrossOver에서 Steam bottle의 Steam을 실행합니다.
 
 ```text
 [crosspuck] crosspuck-driver attached ... host_bridge=true required=true ...
-[crosspuck] startup bridge connect skipped: lazy connect enabled
 ```
 
 `hook install ok`와 API discovery 세부 로그는 debug level 로그이므로 host app이 debug 또는 trace guest severity override를 내렸을 때만 나옵니다.
@@ -205,8 +205,8 @@ tools/smoke-check.sh --bottle Steam
 
 - `OK installed driver`: `steam.exe` 옆에 `hid.dll`이 있습니다.
 - `OK driver log`: 로그 파일이 있습니다.
-- `WARN legacy env registry`: 이전 smoke에서 남은 env registry 파일이 있으며 새 경로에서는 사용하지 않습니다.
-- `WARN log marker missing`: 해당 API 경로를 아직 밟지 않았거나, Steam이 DLL을 로드하지 않았거나, host app이 실행 중이 아니었을 수 있습니다.
+- `WARN log marker missing`: 필수 smoke marker가 없으므로 Steam이 DLL을 로드했는지, host app이 실행 중인지, 해당 API 경로를 밟았는지 확인합니다.
+- `INFO optional log marker missing`: debug/trace logging을 켜지 않았거나 해당 UI 경로를 밟지 않았다면 정상입니다.
 
 ## 9. 통과 기준
 

--- a/crates/crosspuck-driver/docs/crossover-smoke.md
+++ b/crates/crosspuck-driver/docs/crossover-smoke.md
@@ -45,7 +45,7 @@ CrossOver smoke build target on macOS.
 Install next to `Steam.exe`, not into `drive_c/windows/system32`.
 
 ```sh
-tools/install-driver.sh --bottle Steam
+tools/install-driver.sh --bottle Steam --override-dll
 ```
 
 Optional flags:
@@ -54,6 +54,7 @@ Optional flags:
 tools/install-driver.sh \
   --bottle Steam \
   --driver target/x86_64-pc-windows-gnu/release/hid.dll \
+  --override-dll \
   --no-build
 ```
 
@@ -62,8 +63,8 @@ The script:
 - copies `hid.dll` into the detected Steam directory,
 - backs up an existing local `hid.dll` under `crosspuck-backups/`,
 - initializes `crosspuck-driver.log` in the Steam directory,
-- writes `crosspuck-wine-override.reg` in the bottle and imports it with
-  CrossOver `regedit`.
+- when `--override-dll` is set, writes `crosspuck-wine-override.reg` in the
+  bottle and imports it with CrossOver `regedit`.
 
 The installer does not write guest runtime `CROSSPUCK_*` registry/environment
 settings. Guest runtime settings use built-in defaults unless the macOS host app
@@ -72,7 +73,7 @@ sends overrides over the bridge connection.
 ## Wine Loader Override
 
 The install script generates and imports the loader-only Wine override registry
-file automatically.
+file only when run with `--override-dll`.
 
 The generated file is kept in the same bottle:
 
@@ -118,7 +119,6 @@ Expected early log markers:
 
 ```text
 [crosspuck] crosspuck-driver attached ... host_bridge=true required=true ...
-[crosspuck] startup bridge connect skipped: lazy connect enabled
 ```
 
 `hook install ok` and API-level discovery lines are debug-level logs. They are
@@ -168,8 +168,10 @@ After the UI pass, run:
 tools/smoke-check.sh --bottle Steam
 ```
 
-Hard failures mean the DLL or log file is missing. Warnings mean a log marker
-was not observed. Common warning causes:
+Hard failures mean the DLL or log file is missing. Warnings mean a required
+smoke marker was not observed. Optional INFO markers are expected to be absent
+unless debug/trace logging is enabled or the relevant UI path was exercised.
+Common warning causes:
 
 - Steam did not load the local `hid.dll`.
 - The host app was not running.

--- a/crates/crosspuck-driver/src/windows/dll.rs
+++ b/crates/crosspuck-driver/src/windows/dll.rs
@@ -64,22 +64,16 @@ fn attach() {
     }
 
     info_line(&format!(
-        "[crosspuck] crosspuck-driver attached pid={} process={} host_bridge={} required={} trace={} bridge_connect_allowed={} connect_timeout_ms={} handshake_timeout_ms={} io_timeout_ms={} reconnect_interval_ms={}",
+        "[crosspuck] crosspuck-driver attached pid={} process={} host_bridge={} required={} trace={} bridge_connect_allowed={}",
         std::process::id(),
         process,
         host_bridge_enabled,
         host_bridge_required,
         trace_reports,
-        bridge_connect_allowed,
-        connect_timeout_ms,
-        handshake_timeout_ms,
-        io_timeout_ms,
-        reconnect_interval_ms
+        bridge_connect_allowed
     ));
-    if host_bridge_enabled {
-        info_line("[crosspuck] startup bridge connect skipped: lazy connect enabled");
-        if bridge_connect_allowed {
-            state::start_bridge_connector("steam startup");
-        }
-    }
+    debug_line(&format!(
+        "[crosspuck] driver timeouts connect_ms={} handshake_ms={} io_ms={} reconnect_ms={}",
+        connect_timeout_ms, handshake_timeout_ms, io_timeout_ms, reconnect_interval_ms
+    ));
 }

--- a/crates/crosspuck-driver/src/windows/setupapi.rs
+++ b/crates/crosspuck-driver/src/windows/setupapi.rs
@@ -157,8 +157,6 @@ static ORIGINAL_SETUPDI_GET_DEVICE_INSTANCE_ID_A: OnceLock<SetupDiGetDeviceInsta
     OnceLock::new();
 static ORIGINAL_SETUPDI_GET_DEVICE_PROPERTY_W: OnceLock<SetupDiGetDevicePropertyWFn> =
     OnceLock::new();
-static SYNTHETIC_ENUM_BASES: OnceLock<Mutex<Vec<(usize, u32)>>> = OnceLock::new();
-static SYNTHETIC_ELIGIBLE_DEVICE_INFO_SETS: OnceLock<Mutex<Vec<usize>>> = OnceLock::new();
 static VIRTUAL_DEVINSTS: OnceLock<Mutex<Vec<(u32, VirtualHidProfile)>>> = OnceLock::new();
 
 pub fn set_original_setupdi_get_class_devs_w(ptr: *mut c_void) -> Result<(), String> {
@@ -241,7 +239,6 @@ pub unsafe extern "system" fn detoured_setupdi_get_class_devs_w(
     if original.is_some_and(|handle| handle != INVALID_HANDLE_VALUE) {
         let handle = original.unwrap();
         if synthetic_allowed {
-            remember_synthetic_eligible_device_info_set(handle);
             debug_line(&format!(
                 "[crosspuck] SetupDiGetClassDevsW native hid handle={handle:p} flags=0x{flags:08X}"
             ));
@@ -272,7 +269,6 @@ pub unsafe extern "system" fn detoured_setupdi_get_class_devs_a(
     if original.is_some_and(|handle| handle != INVALID_HANDLE_VALUE) {
         let handle = original.unwrap();
         if synthetic_allowed {
-            remember_synthetic_eligible_device_info_set(handle);
             debug_line(&format!(
                 "[crosspuck] SetupDiGetClassDevsA native hid handle={handle:p} flags=0x{flags:08X}"
             ));
@@ -296,21 +292,23 @@ pub unsafe extern "system" fn detoured_setupdi_enum_device_interfaces(
     member_index: u32,
     device_interface_data: *mut c_void,
 ) -> BOOL {
-    if let Some(original) = ORIGINAL_SETUPDI_ENUM_DEVICE_INTERFACES.get().copied() {
-        let result = original(
-            device_info_set,
-            device_info_data,
-            interface_class_guid,
-            member_index,
-            device_interface_data,
-        );
-        if result != 0 {
-            if is_hid_interface_guid(interface_class_guid) {
-                debug_line(&format!(
-                    "[crosspuck] SetupDiEnumDeviceInterfaces native index={member_index} set={device_info_set:p}"
-                ));
+    if device_info_set != SYNTHETIC_DEVICE_INFO_SET {
+        if let Some(original) = ORIGINAL_SETUPDI_ENUM_DEVICE_INTERFACES.get().copied() {
+            let result = original(
+                device_info_set,
+                device_info_data,
+                interface_class_guid,
+                member_index,
+                device_interface_data,
+            );
+            if result != 0 {
+                if is_hid_interface_guid(interface_class_guid) {
+                    debug_line(&format!(
+                        "[crosspuck] SetupDiEnumDeviceInterfaces native index={member_index} set={device_info_set:p}"
+                    ));
+                }
+                return result;
             }
-            return result;
         }
     }
 
@@ -353,6 +351,13 @@ pub unsafe extern "system" fn detoured_setupdi_get_device_interface_detail_w(
             device_info_data,
         );
     }
+    if device_info_set == SYNTHETIC_DEVICE_INFO_SET
+        || device_interface_data_has_crosspuck_reserved(device_interface_data)
+    {
+        debug_line("[crosspuck] SetupDiGetDeviceInterfaceDetailW refusing native call for synthetic interface data");
+        SetLastError(ERROR_NO_MORE_ITEMS);
+        return 0;
+    }
     let result = ORIGINAL_SETUPDI_GET_DEVICE_INTERFACE_DETAIL_W
         .get()
         .copied()
@@ -393,6 +398,13 @@ pub unsafe extern "system" fn detoured_setupdi_get_device_interface_detail_a(
             device_info_data,
         );
     }
+    if device_info_set == SYNTHETIC_DEVICE_INFO_SET
+        || device_interface_data_has_crosspuck_reserved(device_interface_data)
+    {
+        debug_line("[crosspuck] SetupDiGetDeviceInterfaceDetailA refusing native call for synthetic interface data");
+        SetLastError(ERROR_NO_MORE_ITEMS);
+        return 0;
+    }
     let result = ORIGINAL_SETUPDI_GET_DEVICE_INTERFACE_DETAIL_A
         .get()
         .copied()
@@ -421,11 +433,13 @@ pub unsafe extern "system" fn detoured_setupdi_enum_device_info(
     member_index: u32,
     device_info_data: *mut c_void,
 ) -> BOOL {
-    if let Some(original) = ORIGINAL_SETUPDI_ENUM_DEVICE_INFO.get().copied() {
-        let result = original(device_info_set, member_index, device_info_data);
-        if result != 0 {
-            remember_virtual_device_info(device_info_data, "OriginalEnumDeviceInfo");
-            return result;
+    if device_info_set != SYNTHETIC_DEVICE_INFO_SET {
+        if let Some(original) = ORIGINAL_SETUPDI_ENUM_DEVICE_INFO.get().copied() {
+            let result = original(device_info_set, member_index, device_info_data);
+            if result != 0 {
+                remember_virtual_device_info(device_info_data, "OriginalEnumDeviceInfo");
+                return result;
+            }
         }
     }
 
@@ -467,6 +481,10 @@ pub unsafe extern "system" fn detoured_setupdi_get_device_registry_property_w(
             );
         }
     }
+    if device_info_set == SYNTHETIC_DEVICE_INFO_SET {
+        SetLastError(ERROR_NO_MORE_ITEMS);
+        return 0;
+    }
     ORIGINAL_SETUPDI_GET_DEVICE_REGISTRY_PROPERTY_W
         .get()
         .copied()
@@ -507,6 +525,10 @@ pub unsafe extern "system" fn detoured_setupdi_get_device_registry_property_a(
             );
         }
     }
+    if device_info_set == SYNTHETIC_DEVICE_INFO_SET {
+        SetLastError(ERROR_NO_MORE_ITEMS);
+        return 0;
+    }
     ORIGINAL_SETUPDI_GET_DEVICE_REGISTRY_PROPERTY_A
         .get()
         .copied()
@@ -546,6 +568,10 @@ pub unsafe extern "system" fn detoured_setupdi_get_device_instance_id_w(
             );
         }
     }
+    if device_info_set == SYNTHETIC_DEVICE_INFO_SET {
+        SetLastError(ERROR_NO_MORE_ITEMS);
+        return 0;
+    }
     ORIGINAL_SETUPDI_GET_DEVICE_INSTANCE_ID_W
         .get()
         .copied()
@@ -582,6 +608,10 @@ pub unsafe extern "system" fn detoured_setupdi_get_device_instance_id_a(
                 required_size,
             );
         }
+    }
+    if device_info_set == SYNTHETIC_DEVICE_INFO_SET {
+        SetLastError(ERROR_NO_MORE_ITEMS);
+        return 0;
     }
     ORIGINAL_SETUPDI_GET_DEVICE_INSTANCE_ID_A
         .get()
@@ -623,6 +653,10 @@ pub unsafe extern "system" fn detoured_setupdi_get_device_property_w(
             );
         }
     }
+    if device_info_set == SYNTHETIC_DEVICE_INFO_SET {
+        SetLastError(ERROR_NO_MORE_ITEMS);
+        return 0;
+    }
     ORIGINAL_SETUPDI_GET_DEVICE_PROPERTY_W
         .get()
         .copied()
@@ -652,8 +686,7 @@ fn synthetic_profile_for_member(
         return None;
     }
     let catalog = runtime_catalog()?;
-    let base = synthetic_enum_base_index(device_info_set, member_index);
-    let offset = member_index.checked_sub(base)? as usize;
+    let offset = member_index as usize;
     let profile = catalog.descriptors().get(offset)?.profile;
     Some((profile, catalog))
 }
@@ -682,56 +715,6 @@ unsafe fn narrow_z_is_null_or_empty(value: PCSTR) -> bool {
 
 fn synthetic_device_info_set_can_enumerate(device_info_set: HANDLE) -> bool {
     device_info_set == SYNTHETIC_DEVICE_INFO_SET
-        || is_synthetic_eligible_device_info_set(device_info_set)
-}
-
-fn remember_synthetic_eligible_device_info_set(device_info_set: HANDLE) {
-    if device_info_set == INVALID_HANDLE_VALUE {
-        return;
-    }
-    let set_value = device_info_set as usize;
-    let Ok(mut guard) = SYNTHETIC_ELIGIBLE_DEVICE_INFO_SETS
-        .get_or_init(|| Mutex::new(Vec::new()))
-        .lock()
-    else {
-        return;
-    };
-    if !guard.contains(&set_value) {
-        guard.push(set_value);
-    }
-}
-
-fn is_synthetic_eligible_device_info_set(device_info_set: HANDLE) -> bool {
-    let set_value = device_info_set as usize;
-    SYNTHETIC_ELIGIBLE_DEVICE_INFO_SETS
-        .get_or_init(|| Mutex::new(Vec::new()))
-        .lock()
-        .is_ok_and(|guard| guard.contains(&set_value))
-}
-
-fn synthetic_enum_base_index(device_info_set: HANDLE, member_index: u32) -> u32 {
-    if device_info_set == SYNTHETIC_DEVICE_INFO_SET {
-        return 0;
-    }
-
-    let set_value = device_info_set as usize;
-    let mut guard = match SYNTHETIC_ENUM_BASES
-        .get_or_init(|| Mutex::new(Vec::new()))
-        .lock()
-    {
-        Ok(guard) => guard,
-        Err(_) => return member_index,
-    };
-
-    if let Some((_, base)) = guard
-        .iter()
-        .find(|(stored_set, _)| *stored_set == set_value)
-    {
-        return *base;
-    }
-
-    guard.push((set_value, member_index));
-    member_index
 }
 
 unsafe fn synthesize_device_interface_detail_w(
@@ -1174,6 +1157,14 @@ unsafe fn virtual_profile_for_device_interface_data(
     virtual_profile_for_interface_reserved(data.reserved)
 }
 
+unsafe fn device_interface_data_has_crosspuck_reserved(device_interface_data: *mut c_void) -> bool {
+    if device_interface_data.is_null() {
+        return false;
+    }
+    let data = &*(device_interface_data as *const SpDeviceInterfaceData);
+    is_crosspuck_interface_reserved(data.reserved)
+}
+
 unsafe fn virtual_profile_for_device_info_data(
     device_info_data: *mut c_void,
 ) -> Option<VirtualHidProfile> {
@@ -1237,7 +1228,7 @@ fn interface_reserved(profile: VirtualHidProfile) -> usize {
 }
 
 fn virtual_profile_for_interface_reserved(reserved: usize) -> Option<VirtualHidProfile> {
-    if reserved & 0xFFFF_FFFF_FFFF_0000 != VIRTUAL_INTERFACE_RESERVED_BASE {
+    if !is_crosspuck_interface_reserved(reserved) {
         return None;
     }
     match (reserved & 0xFFFF) as u8 {
@@ -1248,6 +1239,10 @@ fn virtual_profile_for_interface_reserved(reserved: usize) -> Option<VirtualHidP
         6 => Some(VirtualHidProfile::VendorDongle),
         _ => None,
     }
+}
+
+fn is_crosspuck_interface_reserved(reserved: usize) -> bool {
+    reserved & 0xFFFF_FFFF_FFFF_0000 == VIRTUAL_INTERFACE_RESERVED_BASE
 }
 
 fn synthetic_devinst(profile: VirtualHidProfile) -> u32 {

--- a/crates/crosspuck-driver/src/windows/state.rs
+++ b/crates/crosspuck-driver/src/windows/state.rs
@@ -4,14 +4,12 @@ use crosspuck_core::guest_driver::{
     VirtualHidProfileCatalog,
 };
 use std::sync::{Mutex, OnceLock};
-use std::thread;
-use std::time::Duration;
 
 static RUNTIME: OnceLock<GuestDriverRuntime> = OnceLock::new();
 static BRIDGE_CONNECT_ALLOWED: OnceLock<bool> = OnceLock::new();
 static LAST_CATALOG_LOG_STATE: OnceLock<Mutex<Option<CatalogLogState>>> = OnceLock::new();
+static LAST_BRIDGE_CONNECT_ERROR: OnceLock<Mutex<Option<String>>> = OnceLock::new();
 static LAST_HOST_LOG_LEVEL_OVERRIDE: OnceLock<Mutex<Option<GuestLogLevel>>> = OnceLock::new();
-static BRIDGE_CONNECTOR_STARTED: OnceLock<()> = OnceLock::new();
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct CatalogLogState {
@@ -53,15 +51,11 @@ pub fn catalog(reason: &'static str) -> Option<VirtualHidProfileCatalog> {
         return catalog;
     }
 
-    start_bridge_connector(reason);
     let before = runtime.snapshot();
     let catalog = match runtime.catalog_result() {
         Ok(catalog) => catalog,
         Err(error) => {
-            set_session_trace_id(runtime.session_trace_id());
-            error_line(&format!(
-                "[crosspuck] lazy bridge connect failed reason={reason}: {error}"
-            ));
+            log_bridge_connect_failed(runtime, reason, &error.to_string());
             return None;
         }
     };
@@ -69,56 +63,6 @@ pub fn catalog(reason: &'static str) -> Option<VirtualHidProfileCatalog> {
     let after = runtime.snapshot();
     log_catalog_state(reason, &before, &after, catalog.is_some());
     catalog
-}
-
-pub fn start_bridge_connector(reason: &'static str) {
-    if !bridge_connect_allowed() {
-        return;
-    }
-
-    if BRIDGE_CONNECTOR_STARTED.set(()).is_err() {
-        return;
-    }
-
-    thread::spawn(move || {
-        for attempt in 1..=8 {
-            let Some(runtime) = runtime() else {
-                return;
-            };
-            let snapshot = runtime.snapshot();
-            if snapshot.bridge_connected {
-                apply_connection_logging(runtime);
-                info_line(&format!(
-                    "[crosspuck] background bridge connector already connected reason={reason} identity={:?} profiles={}",
-                    snapshot.identity_state, snapshot.advertised_profiles
-                ));
-                return;
-            }
-
-            debug_line(&format!(
-                "[crosspuck] background bridge connect attempt={attempt}/8 reason={reason}"
-            ));
-            match runtime.connect_bridge() {
-                Ok(()) => {
-                    apply_connection_logging(runtime);
-                    let snapshot = runtime.snapshot();
-                    info_line(&format!(
-                        "[crosspuck] background bridge connect ok reason={reason} identity={:?} profiles={} open_handles={}",
-                        snapshot.identity_state, snapshot.advertised_profiles, snapshot.open_handles
-                    ));
-                    return;
-                }
-                Err(error) => {
-                    set_session_trace_id(runtime.session_trace_id());
-                    error_line(&format!(
-                        "[crosspuck] background bridge connect failed attempt={attempt}/8 reason={reason}: {error}"
-                    ));
-                }
-            }
-
-            thread::sleep(Duration::from_millis(500));
-        }
-    });
 }
 
 pub fn catalog_if_connected(reason: &'static str) -> Option<VirtualHidProfileCatalog> {
@@ -135,6 +79,36 @@ pub fn catalog_if_connected(reason: &'static str) -> Option<VirtualHidProfileCat
         ));
     }
     catalog
+}
+
+fn log_bridge_connect_failed(
+    runtime: &GuestDriverRuntime,
+    reason: &'static str,
+    error_message: &str,
+) {
+    let Ok(mut last) = LAST_BRIDGE_CONNECT_ERROR
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+    else {
+        return;
+    };
+    if last.as_deref() == Some(error_message) {
+        return;
+    }
+    *last = Some(error_message.to_string());
+    set_session_trace_id(runtime.session_trace_id());
+    error_line(&format!(
+        "[crosspuck] lazy bridge connect failed reason={reason}: {error_message}"
+    ));
+}
+
+fn clear_bridge_connect_error() {
+    if let Ok(mut last) = LAST_BRIDGE_CONNECT_ERROR
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+    {
+        *last = None;
+    }
 }
 
 fn apply_connection_logging(runtime: &GuestDriverRuntime) {
@@ -198,6 +172,7 @@ fn log_catalog_state(
     }
 
     if after.bridge_connected {
+        clear_bridge_connect_error();
         set_session_trace_id(after.session_trace_id);
         info_line(&format!(
             "[crosspuck] lazy bridge connect ok reason={reason} identity={:?} profiles={} open_handles={}",

--- a/tools/README.md
+++ b/tools/README.md
@@ -15,11 +15,16 @@ only the app-local `hid.dll` and intentionally leaves Wine registry settings
 unchanged. These shell commands are for manual development and smoke-test
 workflows.
 
-Install the production guest driver next to `Steam.exe` and import the Wine
-loader override:
+Copy the production guest driver next to `Steam.exe`:
 
 ```sh
 tools/install-driver.sh --bottle Steam
+```
+
+To also import Wine's `hid=native,builtin` loader override:
+
+```sh
+tools/install-driver.sh --bottle Steam --override-dll
 ```
 
 Useful options:
@@ -32,7 +37,8 @@ tools/install-driver.sh \
 ```
 
 The script copies `hid.dll`, backs up any existing app-local `hid.dll`, and
-initializes `crosspuck-driver.log` next to Steam. It also writes
+initializes `crosspuck-driver.log` next to Steam. By default it does not call
+CrossOver `regedit`. With `--override-dll`, it writes
 `crosspuck-wine-override.reg` into the bottle and imports it with the matching
 CrossOver app, using CrossOver Preview first for preview-marked bottles and
 CrossOver first for regular bottles. It does not write guest runtime
@@ -106,9 +112,9 @@ After exercising the Steam UI, run:
 tools/smoke-check.sh --bottle Steam
 ```
 
-Warnings from this script are hints, not hard failures. Missing trace markers
-usually mean the corresponding Steam UI path was not exercised, the host app was
-not running, or debug/trace logging was not enabled.
+Warnings from this script indicate missing required smoke markers. Optional INFO
+markers are expected to be absent unless the corresponding Steam UI path was
+exercised or debug/trace logging was enabled.
 
 ## Development Checks
 

--- a/tools/install-driver.sh
+++ b/tools/install-driver.sh
@@ -4,14 +4,15 @@ set -euo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  tools/install-driver.sh [--bottle NAME | --bottle-path PATH] [--driver PATH] [--steam-dir PATH] [--no-build]
+  tools/install-driver.sh [--bottle NAME | --bottle-path PATH] [--driver PATH] [--steam-dir PATH] [--override-dll] [--no-build]
 
 Installs the production crosspuck-driver hid.dll next to Steam.exe inside a
 CrossOver bottle.
 
 The script verifies that the Rust Windows GNU target is installed, builds the
 driver with Cargo unless --no-build is provided, and then installs the resulting
-DLL. It also writes crosspuck-wine-override.reg in the bottle and imports it
+DLL. By default it only copies the driver and prepares the driver log. Pass
+--override-dll to write crosspuck-wine-override.reg in the bottle and import it
 with the matching CrossOver regedit, setting hid=native,builtin. It does not
 write guest runtime CROSSPUCK_* registry/environment settings. Guest runtime
 settings use built-in defaults unless the macOS host app sends overrides over
@@ -23,6 +24,7 @@ Options:
   --driver PATH          hid.dll path to copy. Defaults to the Cargo release output.
   --steam-dir PATH       Steam directory inside the bottle. Auto-detected from Steam.exe.
   --log-file PATH        Unix path for the driver log file. Defaults to the Steam directory.
+  --override-dll         Import Wine's hid=native,builtin DLL override.
   --no-build             Do not build the driver before copying --driver.
   --help                 Show this help.
 
@@ -41,6 +43,7 @@ driver_path="$repo_root/target/$driver_target/release/hid.dll"
 steam_dir=""
 log_file=""
 no_build="0"
+override_dll="0"
 
 ensure_driver_target_installed() {
   if ! command -v rustup >/dev/null 2>&1; then
@@ -121,6 +124,10 @@ while [[ $# -gt 0 ]]; do
     --log-file)
       log_file="${2:?missing value for --log-file}"
       shift 2
+      ;;
+    --override-dll)
+      override_dll="1"
+      shift
       ;;
     --no-build)
       no_build="1"
@@ -209,18 +216,20 @@ find "$steam_dir" -name crosspuck-driver.log -type f ! -path "$log_file" -delete
 find "$bottle_path/drive_c/users" -name crosspuck-driver.log -type f -delete 2>/dev/null || true
 : > "$log_file"
 
-wine_override_file="$bottle_path/crosspuck-wine-override.reg"
-cat > "$wine_override_file" <<EOF
+if [[ "$override_dll" == "1" ]]; then
+  wine_override_file="$bottle_path/crosspuck-wine-override.reg"
+  cat > "$wine_override_file" <<EOF
 Windows Registry Editor Version 5.00
 
 [HKEY_CURRENT_USER\\Software\\Wine\\DllOverrides]
 "hid"="native,builtin"
 EOF
-crossover_wine="$(find_crossover_wine)" || {
-  echo "Could not find CrossOver wine command to import $wine_override_file" >&2
-  exit 1
-}
-"$crossover_wine" --bottle "$bottle_name" --no-gui regedit /S "$wine_override_file"
+  crossover_wine="$(find_crossover_wine)" || {
+    echo "Could not find CrossOver wine command to import $wine_override_file" >&2
+    exit 1
+  }
+  "$crossover_wine" --bottle "$bottle_name" --no-gui --no-update regedit /S "$wine_override_file"
+fi
 
 cat <<EOF
 Installed CrossPuck driver:
@@ -232,11 +241,19 @@ EOF
 
 cat <<EOF
 
-Wine loader override registry file:
-  $wine_override_file
-Imported with:
-  $crossover_wine
+Wine loader override:
 EOF
+if [[ "$override_dll" == "1" ]]; then
+  cat <<EOF
+  imported hid=native,builtin
+  file: $wine_override_file
+  command: $crossover_wine
+EOF
+else
+  cat <<EOF
+  not imported; pass --override-dll to set hid=native,builtin
+EOF
+fi
 
 cat <<EOF
 

--- a/tools/smoke-check.sh
+++ b/tools/smoke-check.sh
@@ -92,6 +92,16 @@ check_log() {
   fi
 }
 
+check_optional_log() {
+  local label="$1"
+  local pattern="$2"
+  if [[ -f "$log_file" ]] && grep -Eq "$pattern" "$log_file"; then
+    echo "OK   optional log marker: $label"
+  else
+    echo "INFO optional log marker missing: $label"
+  fi
+}
+
 check_file "installed driver" "$driver_dll"
 check_file "driver log" "$log_file"
 
@@ -103,11 +113,11 @@ if [[ -f "$wine_override_reg" ]]; then
 fi
 
 check_log "DLL attach" "crosspuck-driver attached"
-check_log "hook install" "hook install ok|hook groups installed"
 check_log "host bridge/catalog result" "startup bridge connect|lazy bridge connect|catalog available|CreateFile virtual|SDL_hid_enumerate|SetupDiGetClassDevs"
 check_log "HID discovery or caps" "HidP_GetCaps|SetupDi|CreateFile|SDL_hid_enumerate|SDL_hid_open_path"
-check_log "input/feature/write trace" "ReadFile|HidD_GetInputReport|HidD_GetFeature|HidD_SetFeature|HidD_SetOutputReport|WriteFile|SDL_hid_read_timeout|SDL_hid_get_feature_report|SDL_hid_send_feature_report|SDL_hid_write"
-check_log "DeviceIoControl trace" "DeviceIoControl"
+check_optional_log "debug hook install" "hook install ok|hook groups installed"
+check_optional_log "trace input/feature/write" "ReadFile|HidD_GetInputReport|HidD_GetFeature|HidD_SetFeature|HidD_SetOutputReport|WriteFile|SDL_hid_read_timeout|SDL_hid_get_feature_report|SDL_hid_send_feature_report|SDL_hid_write"
+check_optional_log "trace DeviceIoControl" "DeviceIoControl"
 
 if [[ "$failures" -gt 0 ]]; then
   exit 1
@@ -118,4 +128,4 @@ echo "Bottle: $bottle_name"
 echo "Steam:  $steam_exe"
 echo "Log:    $log_file"
 echo
-echo "WARN markers are smoke hints, not hard failures. Missing trace markers usually mean Steam did not load the DLL, the host app was not running, or the relevant UI path was not exercised yet."
+echo "WARN markers indicate required smoke signals. INFO optional markers are expected to be absent unless debug/trace logging is enabled or the relevant UI path was exercised."


### PR DESCRIPTION
## Summary

This PR hardens the CrossPuck guest driver and CrossOver install/test workflow after validating Steam Controller Puck + controller recognition on both CrossOver stable and CrossOver Preview.

## Changes

- Make `tools/install-driver.sh` copy `hid.dll` by default.
- Require `--override-dll` before importing Wine's `hid=native,builtin` registry override.
- Remove eager/background bridge connection from the guest driver and rely on lazy bridge connection during HID discovery/open.
- Reduce noisy INFO logs and deduplicate repeated lazy bridge connection failures.
- Prevent synthetic SetupAPI device entries from leaking into native HID device sets.
- Return `DeviceDisconnected` when the macOS host cannot open the real HID device instead of advertising a successful session too early.
- Improve macOS HID permission diagnostics for `IOServiceOpen failed: 0xe00002e2`.
- Update smoke-test output so debug/trace-only markers are reported as optional INFO instead of WARN.
- Update CrossOver smoke docs and installer docs.