### PR TITLE
Add CrossOver bottle selection to the host app menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ The installer handles both `/Applications/CrossOver.app` and
 CrossOver Preview first; regular bottles import through CrossOver first; the
 other app is used as a fallback when only one is installed.
 
+### Bottles In A Non-Default Location
+
+CrossPuck auto-detects the Steam bottle under
+`~/Library/Application Support/CrossOver/Bottles` by default. If your bottle
+lives elsewhere (for example on an external drive), or several bottles have
+Steam installed, use the menu bar `Advanced` > `Bottle Path` >
+`Choose Bottle...` item to pick the CrossOver bottle CrossPuck should use. The
+choice is remembered across launches; the `Bottle:` line shows the bottle
+currently in use, and `Reset to Default` returns to auto-detection. Two
+environment variables override this for scripting: `CROSSPUCK_BOTTLE_PATH`
+selects a specific bottle and takes precedence over the menu selection, and
+`CROSSPUCK_BOTTLES_DIR` changes the directory that auto-detection scans.
+
 ### Verify Wine DLL Override
 
 If Steam does not see the controller, verify the Wine DLL override manually:

--- a/crates/crosspuck-app/Cargo.toml
+++ b/crates/crosspuck-app/Cargo.toml
@@ -30,12 +30,16 @@ objc2-app-kit = { workspace = true, features = [
     "NSImage",
     "NSMenu",
     "NSMenuItem",
+    "NSOpenPanel",
+    "NSPanel",
     "NSResponder",
     "NSRunningApplication",
+    "NSSavePanel",
     "NSStatusBar",
     "NSStatusBarButton",
     "NSStatusItem",
     "NSView",
+    "NSWindow",
     "objc2-core-foundation",
 ] }
 objc2-foundation = { workspace = true, features = [
@@ -45,6 +49,8 @@ objc2-foundation = { workspace = true, features = [
     "NSObject",
     "NSString",
     "NSTimer",
+    "NSURL",
+    "NSUserDefaults",
 ] }
 oslog.workspace = true
 pprof = { version = "0.15.0", optional = true, features = ["flamegraph"] }

--- a/crates/crosspuck-app/src/driver_install.rs
+++ b/crates/crosspuck-app/src/driver_install.rs
@@ -675,7 +675,16 @@ fn import_registry_file(
         .file_name()
         .and_then(OsStr::to_str)
         .unwrap_or(DEFAULT_STEAM_BOTTLE_NAME);
-    let output = Command::new(&tool.wine_path)
+    let mut command = Command::new(&tool.wine_path);
+    // CrossOver resolves `--bottle` names against its own configured bottles
+    // directory, which can differ from the directory CrossPuck discovered the
+    // bottle in (for example when bottles live on an external drive). Pin
+    // CX_BOTTLE_PATH, which CrossOver honors first, to the discovered bottle's
+    // parent so the import targets exactly the bottle that was inspected.
+    if let Some(bottles_dir) = bottle_path.parent() {
+        command.env("CX_BOTTLE_PATH", bottles_dir);
+    }
+    let output = command
         .arg("--bottle")
         .arg(bottle_name)
         .arg("--no-gui")
@@ -1116,6 +1125,7 @@ mod tests {
         let log = fs::read_to_string(wine_log).unwrap();
         assert!(log.contains("--bottle Steam --no-gui regedit /S"));
         assert!(log.contains(reg_file_path.to_str().unwrap()));
+        assert!(log.contains(&format!("CX_BOTTLE_PATH={}", dir.path().display())));
     }
 
     #[test]
@@ -1243,7 +1253,8 @@ mod tests {
             &wine_path,
             format!(
                 r#"#!/bin/sh
-printf '%s\n' "$*" >> {}
+printf '%s\n' "$*" >> {0}
+printf 'CX_BOTTLE_PATH=%s\n' "${{CX_BOTTLE_PATH:-}}" >> {0}
 last=''
 for arg in "$@"; do
   last="$arg"

--- a/crates/crosspuck-app/src/driver_install.rs
+++ b/crates/crosspuck-app/src/driver_install.rs
@@ -9,7 +9,7 @@ use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const BOTTLE_PATH_ENV: &str = "CROSSPUCK_BOTTLE_PATH";
+pub const BOTTLE_PATH_ENV: &str = "CROSSPUCK_BOTTLE_PATH";
 const EMBEDDED_DRIVER_PATH_ENV: &str = "CROSSPUCK_EMBEDDED_DRIVER_PATH";
 const DEFAULT_STEAM_BOTTLE_NAME: &str = "Steam";
 const DRIVER_TARGET_RELATIVE_PATH: &[&str] =
@@ -818,7 +818,7 @@ fn default_repo_root() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
-fn default_crossover_bottles_dir() -> Option<PathBuf> {
+pub fn default_crossover_bottles_dir() -> Option<PathBuf> {
     let home = env::var_os("HOME").map(PathBuf::from)?;
     Some(
         CROSSOVER_BOTTLES_RELATIVE_PATH

--- a/crates/crosspuck-app/src/main.rs
+++ b/crates/crosspuck-app/src/main.rs
@@ -34,6 +34,8 @@ mod probe {
 #[cfg(target_os = "macos")]
 mod runtime;
 #[cfg(target_os = "macos")]
+mod settings;
+#[cfg(target_os = "macos")]
 mod user_activity;
 
 #[cfg(target_os = "macos")]
@@ -63,12 +65,13 @@ mod macos {
     };
     use objc2_app_kit::{
         NSApplication, NSApplicationActivationPolicy, NSCellImagePosition, NSImage, NSImageScaling,
-        NSMenu, NSMenuDelegate, NSMenuItem, NSSquareStatusItemLength, NSStatusBar, NSStatusItem,
+        NSMenu, NSMenuDelegate, NSMenuItem, NSModalResponseOK, NSOpenPanel,
+        NSSquareStatusItemLength, NSStatusBar, NSStatusItem,
     };
     use objc2_foundation::{
-        NSAutoreleasePool, NSBundle, NSObject, NSObjectProtocol, NSString, NSTimer,
+        NSAutoreleasePool, NSBundle, NSObject, NSObjectProtocol, NSString, NSTimer, NSURL,
     };
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::process::ExitCode;
     use std::sync::{Arc, Mutex};
     use std::thread;
@@ -81,6 +84,7 @@ mod macos {
         _menu_delegate: Retained<StateMenuDelegate>,
         _refresh_timer: Retained<NSTimer>,
         _driver_controller: Retained<DriverInstallController>,
+        _bottle_controller: Retained<BottleController>,
         _quit_controller: Retained<QuitController>,
     }
 
@@ -93,6 +97,9 @@ mod macos {
         driver_status: Retained<NSMenuItem>,
         driver_action: Retained<NSMenuItem>,
         driver_uninstall: Retained<NSMenuItem>,
+        bottle_info: Retained<NSMenuItem>,
+        bottle_choose: Retained<NSMenuItem>,
+        bottle_reset: Retained<NSMenuItem>,
     }
 
     #[derive(Clone)]
@@ -213,6 +220,91 @@ mod macos {
         }
     }
 
+    struct BottleControllerIvars {
+        driver_state: Arc<DriverMenuState>,
+        items: StateMenuItems,
+    }
+
+    define_class!(
+        #[unsafe(super = NSObject)]
+        #[thread_kind = objc2::MainThreadOnly]
+        #[ivars = BottleControllerIvars]
+        struct BottleController;
+
+        unsafe impl NSObjectProtocol for BottleController {}
+
+        impl BottleController {
+            #[unsafe(method(chooseBottle:))]
+            fn choose_bottle(&self, _sender: Option<&AnyObject>) {
+                let mtm = self.mtm();
+                let panel = NSOpenPanel::openPanel(mtm);
+                panel.setCanChooseDirectories(true);
+                panel.setCanChooseFiles(false);
+                panel.setAllowsMultipleSelection(false);
+                panel.setMessage(Some(&NSString::from_str(
+                    "Select the CrossOver bottle CrossPuck should use",
+                )));
+
+                // Start next to the current bottle when one is set, otherwise
+                // at the bottles root that auto-detection scans.
+                let context = self.ivars().driver_state.current_context();
+                let start_dir = context
+                    .bottle_path
+                    .as_deref()
+                    .and_then(Path::parent)
+                    .map(Path::to_path_buf)
+                    .or(context.crossover_bottles_dir)
+                    .filter(|path| path.is_dir());
+                if let Some(dir) = start_dir {
+                    let url = NSURL::fileURLWithPath(&NSString::from_str(&dir.to_string_lossy()));
+                    panel.setDirectoryURL(Some(&url));
+                }
+
+                // An accessory (menu bar) app is not frontmost, so bring it
+                // forward before running the modal or the picker hides behind
+                // other windows.
+                activate_app(mtm);
+                if panel.runModal() != NSModalResponseOK {
+                    return;
+                }
+                let Some(path) = panel.URL().and_then(|url| url.path()) else {
+                    return;
+                };
+                let path = PathBuf::from(path.to_string());
+                crate::settings::set_stored_bottle_path(&path);
+                self.apply_bottle_path_change();
+            }
+
+            #[unsafe(method(resetBottle:))]
+            fn reset_bottle(&self, _sender: Option<&AnyObject>) {
+                crate::settings::clear_stored_bottle_path();
+                self.apply_bottle_path_change();
+            }
+        }
+    );
+
+    impl BottleController {
+        fn new(
+            mtm: MainThreadMarker,
+            driver_state: Arc<DriverMenuState>,
+            items: StateMenuItems,
+        ) -> Retained<Self> {
+            let this = Self::alloc(mtm).set_ivars(BottleControllerIvars {
+                driver_state,
+                items,
+            });
+            unsafe { msg_send![super(this), init] }
+        }
+
+        fn apply_bottle_path_change(&self) {
+            let driver_state = &self.ivars().driver_state;
+            driver_state.set_bottle_path(crate::settings::resolve_bottle_path());
+            driver_state.refresh_status();
+            refresh_driver_items(driver_state, &self.ivars().items);
+            refresh_bottle_items(driver_state, &self.ivars().items);
+        }
+    }
+
     struct QuitControllerIvars {
         app: Retained<NSApplication>,
         service_handle: HostServiceHandle,
@@ -305,12 +397,15 @@ mod macos {
 
         let menu = NSMenu::new(mtm);
         menu.setAutoenablesItems(false);
-        let driver_state = Arc::new(DriverMenuState::new(
-            DriverInstallContext::from_environment(bundle_resources_dir()),
-        ));
+        let mut driver_context = DriverInstallContext::from_environment(bundle_resources_dir());
+        driver_context.crossover_bottles_dir = crate::settings::resolve_bottles_dir();
+        driver_context.bottle_path = crate::settings::resolve_bottle_path();
+        let driver_state = Arc::new(DriverMenuState::new(driver_context));
         driver_state.refresh_status();
 
         let empty_key = NSString::from_str("");
+        let bottle_menu = NSMenu::new(mtm);
+        bottle_menu.setAutoenablesItems(false);
         let state_items = StateMenuItems {
             status: menu.addItemWithTitle_action_keyEquivalent(
                 &NSString::from_str("Status: Starting"),
@@ -351,12 +446,46 @@ mod macos {
                 Some(sel!(uninstallDriver:)),
                 &empty_key,
             ),
+            bottle_info: bottle_menu.addItemWithTitle_action_keyEquivalent(
+                &NSString::from_str("Bottle: -"),
+                None,
+                &empty_key,
+            ),
+            bottle_choose: bottle_menu.addItemWithTitle_action_keyEquivalent(
+                &NSString::from_str("Choose Bottle..."),
+                Some(sel!(chooseBottle:)),
+                &empty_key,
+            ),
+            bottle_reset: bottle_menu.addItemWithTitle_action_keyEquivalent(
+                &NSString::from_str("Reset to Default"),
+                Some(sel!(resetBottle:)),
+                &empty_key,
+            ),
         };
         state_items.status.setEnabled(false);
         state_items.puck.setEnabled(false);
         state_items.guest.setEnabled(false);
         state_items.error.setEnabled(false);
         state_items.driver_status.setEnabled(false);
+        state_items.bottle_info.setEnabled(false);
+
+        // Advanced > Bottle Path > (bottle items)
+        let separator = NSMenuItem::separatorItem(mtm);
+        menu.addItem(&separator);
+        let advanced_menu = NSMenu::new(mtm);
+        advanced_menu.setAutoenablesItems(false);
+        let bottle_path_item = advanced_menu.addItemWithTitle_action_keyEquivalent(
+            &NSString::from_str("Bottle Path"),
+            None,
+            &empty_key,
+        );
+        bottle_path_item.setSubmenu(Some(&bottle_menu));
+        let advanced_item = menu.addItemWithTitle_action_keyEquivalent(
+            &NSString::from_str("Advanced"),
+            None,
+            &empty_key,
+        );
+        advanced_item.setSubmenu(Some(&advanced_menu));
 
         let driver_controller =
             DriverInstallController::new(mtm, Arc::clone(&driver_state), state_items.clone());
@@ -366,6 +495,15 @@ mod macos {
         state_items
             .driver_uninstall
             .setTarget(Some(driver_controller.as_ref()));
+
+        let bottle_controller =
+            BottleController::new(mtm, Arc::clone(&driver_state), state_items.clone());
+        state_items
+            .bottle_choose
+            .setTarget(Some(bottle_controller.as_ref()));
+        state_items
+            .bottle_reset
+            .setTarget(Some(bottle_controller.as_ref()));
 
         let menu_delegate = StateMenuDelegate::new(
             mtm,
@@ -404,6 +542,7 @@ mod macos {
             _menu_delegate: menu_delegate,
             _refresh_timer: refresh_timer,
             _driver_controller: driver_controller,
+            _bottle_controller: bottle_controller,
             _quit_controller: quit_controller,
         }
     }
@@ -428,6 +567,53 @@ mod macos {
             .error
             .setTitle(&NSString::from_str(&format!("Last error: {}", view.error)));
         refresh_driver_items(driver_state, items);
+        refresh_bottle_items(driver_state, items);
+    }
+
+    fn refresh_bottle_items(driver_state: &DriverMenuState, items: &StateMenuItems) {
+        let env_override = crate::settings::env_override_active();
+        // When CROSSPUCK_BOTTLE_PATH is set it wins over any menu selection, so
+        // say so and disable the picker rather than letting Choose/Reset look
+        // like they do nothing.
+        let label = match driver_state.current_context().bottle_path.as_deref() {
+            Some(path) if env_override => {
+                format!(
+                    "Bottle: {} (set by CROSSPUCK_BOTTLE_PATH)",
+                    display_path(path)
+                )
+            }
+            Some(path) => format!("Bottle: {}", display_path(path)),
+            None => match driver_state.discovered_bottle() {
+                Some(path) => format!("Bottle: {} (auto)", display_path(&path)),
+                None => "Bottle: (auto)".to_string(),
+            },
+        };
+        items.bottle_info.setTitle(&NSString::from_str(&label));
+        items.bottle_choose.setEnabled(!env_override);
+        // "Reset to Default" only makes sense when a bottle has been chosen and
+        // the env var is not overriding it.
+        items
+            .bottle_reset
+            .setEnabled(!env_override && crate::settings::stored_bottle_path().is_some());
+    }
+
+    fn display_path(path: &Path) -> String {
+        if let Some(home) = std::env::var_os("HOME") {
+            if let Ok(rest) = path.strip_prefix(&home) {
+                if rest.as_os_str().is_empty() {
+                    return "~".to_string();
+                }
+                return format!("~/{}", rest.display());
+            }
+        }
+        path.display().to_string()
+    }
+
+    // `NSApplication::activate()` is the modern replacement but is macOS 14+
+    // only, so keep using `activateIgnoringOtherApps` for broader compatibility.
+    #[allow(deprecated)]
+    fn activate_app(mtm: MainThreadMarker) {
+        NSApplication::sharedApplication(mtm).activateIgnoringOtherApps(true);
     }
 
     fn refresh_driver_items(driver_state: &DriverMenuState, items: &StateMenuItems) {
@@ -447,7 +633,7 @@ mod macos {
 
     #[derive(Debug)]
     struct DriverMenuState {
-        context: DriverInstallContext,
+        context: Mutex<DriverInstallContext>,
         snapshot: Mutex<DriverMenuSnapshot>,
     }
 
@@ -473,9 +659,38 @@ mod macos {
     impl DriverMenuState {
         fn new(context: DriverInstallContext) -> Self {
             Self {
-                context,
+                context: Mutex::new(context),
                 snapshot: Mutex::new(DriverMenuSnapshot::Checking),
             }
+        }
+
+        /// Clone the current install context. The bottles root inside it can be
+        /// swapped at runtime via [`set_bottles_dir`], so callers always read a
+        /// fresh copy rather than capturing it once.
+        fn current_context(&self) -> DriverInstallContext {
+            self.context
+                .lock()
+                .map(|context| context.clone())
+                .unwrap_or_default()
+        }
+
+        /// Point the driver workflow at an explicit CrossOver bottle, or
+        /// `None` to fall back to automatic detection.
+        fn set_bottle_path(&self, bottle_path: Option<PathBuf>) {
+            if let Ok(mut context) = self.context.lock() {
+                context.bottle_path = bottle_path;
+            }
+        }
+
+        /// Bottle found by the most recent driver status check, if any.
+        fn discovered_bottle(&self) -> Option<PathBuf> {
+            self.snapshot
+                .lock()
+                .ok()
+                .and_then(|snapshot| match &*snapshot {
+                    DriverMenuSnapshot::Status(status) => status.bottle_path.clone(),
+                    _ => None,
+                })
         }
 
         fn refresh_status(&self) {
@@ -484,7 +699,7 @@ mod macos {
             }
             crate::probe::note_driver_status_check();
 
-            let status = check_driver_install_status(&self.context);
+            let status = check_driver_install_status(&self.current_context());
             if let Ok(mut snapshot) = self.snapshot.lock() {
                 *snapshot = DriverMenuSnapshot::Status(status);
             }
@@ -501,7 +716,7 @@ mod macos {
             drop(snapshot);
 
             let state = Arc::clone(self);
-            let context = self.context.clone();
+            let context = self.current_context();
             thread::spawn(move || {
                 let next = match install_driver(&context) {
                     Ok(result) => {
@@ -544,7 +759,7 @@ mod macos {
             drop(snapshot);
 
             let state = Arc::clone(self);
-            let context = self.context.clone();
+            let context = self.current_context();
             thread::spawn(move || {
                 let next = match uninstall_driver(&context) {
                     Ok(result) => {

--- a/crates/crosspuck-app/src/settings.rs
+++ b/crates/crosspuck-app/src/settings.rs
@@ -1,0 +1,122 @@
+//! Persistent user preferences for the CrossPuck menu bar app.
+//!
+//! Today this is just the CrossOver bottle selection. CrossPuck normally
+//! auto-detects the Steam bottle under the default CrossOver bottles
+//! directory, but bottles can live elsewhere (for example on an external
+//! drive) and a machine can have several bottles with Steam installed, so the
+//! menu lets the user pick the exact bottle and remembers the choice across
+//! launches via macOS `UserDefaults`.
+//!
+//! The effective bottle is resolved in priority order:
+//!   1. the `CROSSPUCK_BOTTLE_PATH` environment variable,
+//!   2. the bottle chosen from the menu (persisted in `UserDefaults`),
+//!   3. automatic detection under the bottles root, which itself honors the
+//!      `CROSSPUCK_BOTTLES_DIR` environment variable before the default
+//!      CrossOver location.
+
+use crate::driver_install::{default_crossover_bottles_dir, BOTTLE_PATH_ENV};
+use objc2::runtime::AnyObject;
+use objc2_foundation::{NSString, NSUserDefaults};
+use std::env;
+use std::path::{Path, PathBuf};
+
+/// Environment override for the bottles root scanned during auto-detection.
+const BOTTLES_DIR_ENV: &str = "CROSSPUCK_BOTTLES_DIR";
+/// `UserDefaults` key holding the user-selected bottle.
+const BOTTLE_PATH_DEFAULTS_KEY: &str = "BottlePath";
+
+/// Resolve the explicitly selected CrossOver bottle, if any (env var first,
+/// then the persisted menu selection). `None` means auto-detection.
+pub fn resolve_bottle_path() -> Option<PathBuf> {
+    resolve_bottle_path_from(env_bottle_path(), stored_bottle_path())
+}
+
+/// The bottle persisted via the menu, if the user has chosen one.
+pub fn stored_bottle_path() -> Option<PathBuf> {
+    let key = NSString::from_str(BOTTLE_PATH_DEFAULTS_KEY);
+    let value = NSUserDefaults::standardUserDefaults()
+        .stringForKey(&key)?
+        .to_string();
+    (!value.is_empty()).then(|| PathBuf::from(value))
+}
+
+/// Persist a user-selected bottle.
+pub fn set_stored_bottle_path(path: &Path) {
+    let defaults = NSUserDefaults::standardUserDefaults();
+    let key = NSString::from_str(BOTTLE_PATH_DEFAULTS_KEY);
+    let value = NSString::from_str(&path.to_string_lossy());
+    let value_obj: &AnyObject = &value;
+    // SAFETY: `value_obj` is an `NSString`, a valid property-list type for
+    // `UserDefaults`, and `key` is a constant string.
+    unsafe { defaults.setObject_forKey(Some(value_obj), &key) };
+}
+
+/// Forget any user-selected bottle, reverting to the env var / auto-detection.
+pub fn clear_stored_bottle_path() {
+    let defaults = NSUserDefaults::standardUserDefaults();
+    let key = NSString::from_str(BOTTLE_PATH_DEFAULTS_KEY);
+    defaults.removeObjectForKey(&key);
+}
+
+/// Whether `CROSSPUCK_BOTTLE_PATH` is set. While it is, the env var wins over
+/// any menu selection, so the UI disables the bottle picker to avoid silent
+/// no-ops.
+pub fn env_override_active() -> bool {
+    env_bottle_path().is_some()
+}
+
+/// The CrossOver bottles root scanned when no explicit bottle is selected:
+/// the `CROSSPUCK_BOTTLES_DIR` environment variable, then the default
+/// `~/Library/Application Support/CrossOver/Bottles`.
+pub fn resolve_bottles_dir() -> Option<PathBuf> {
+    non_empty_env(BOTTLES_DIR_ENV).or_else(default_crossover_bottles_dir)
+}
+
+fn env_bottle_path() -> Option<PathBuf> {
+    non_empty_env(BOTTLE_PATH_ENV)
+}
+
+fn non_empty_env(name: &str) -> Option<PathBuf> {
+    env::var_os(name)
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+}
+
+/// Pure precedence logic, split out so it can be unit tested without touching
+/// the environment or `UserDefaults`.
+fn resolve_bottle_path_from(
+    env_path: Option<PathBuf>,
+    stored_path: Option<PathBuf>,
+) -> Option<PathBuf> {
+    env_path.or(stored_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path(value: &str) -> Option<PathBuf> {
+        Some(PathBuf::from(value))
+    }
+
+    #[test]
+    fn env_overrides_stored() {
+        assert_eq!(
+            resolve_bottle_path_from(path("/env/Steam"), path("/stored/Steam")),
+            path("/env/Steam")
+        );
+    }
+
+    #[test]
+    fn stored_used_without_env() {
+        assert_eq!(
+            resolve_bottle_path_from(None, path("/stored/Steam")),
+            path("/stored/Steam")
+        );
+    }
+
+    #[test]
+    fn none_means_auto_detection() {
+        assert_eq!(resolve_bottle_path_from(None, None), None);
+    }
+}


### PR DESCRIPTION
Hi, first of all thank you for making this project ! It is awesome to be able to use the Steam controller in Crossover. 

My root folder for bottles lives in my external drive, so I needed a way to be able to select the folder, also I have multiple bottles, so I needed a way to select more than the default one. 

I used Claude for this with Opus 4.8 in xHigh, I have no knowledge of rust (I'm more of a Typescript guy ^^), but I red the entire code of this PR. 

Feel free to merge or discard this PR. Either way it is built and it's working on my machine :)  

And if you want me to do some modifications, I can !

## Summary

This PR lets the host app target a specific CrossOver bottle instead of relying only on auto-detection under the default bottles directory. This supports setups where bottles live in a non-default location (for example on an external drive) or where several bottles contain Steam. Validated end to end on CrossOver Preview with bottles stored on an external drive.

## Changes

- Add an `Advanced` > `Bottle Path` submenu to the menu bar app.
- Add `Choose Bottle...` to pick a CrossOver bottle with the native folder picker; the selection is persisted across launches in `UserDefaults`.
- Show the bottle currently in use in the menu, including the auto-detected one as `Bottle: <path> (auto)`.
- Add `Reset to Default` to return to auto-detection.
- Resolve the bottle as `CROSSPUCK_BOTTLE_PATH`, then the persisted menu selection, then auto-detection; while the environment variable is set, disable the picker and label the menu accordingly instead of silently ignoring clicks.
- Honor a new `CROSSPUCK_BOTTLES_DIR` environment variable for the directory auto-detection scans.
- Import the Wine registry override with `CX_BOTTLE_PATH` pinned to the selected bottle's parent directory, so CrossOver `regedit` targets the same bottle CrossPuck inspected regardless of CrossOver's own bottle directory configuration.
- Document the menu and environment variables in the README.

## Notes

- `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace` pass; new unit tests cover the bottle resolution precedence and the `CX_BOTTLE_PATH` pinning during registry import.
- `cargo check`/`clippy` for `crosspuck-driver` on `x86_64-pc-windows-gnu` pass.
